### PR TITLE
Add comprehensive backend unit tests for C# projects

### DIFF
--- a/Commitments.sln
+++ b/Commitments.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.33402.96
@@ -12,6 +12,14 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Commitments.App", "src\Commitments.App\Commitments.App.csproj", "{0404A7B4-7E86-4CC2-B212-B91A8DEE1183}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Commitments.Core", "src\Commitments.Core\Commitments.Core.csproj", "{E7599E3E-576F-4D76-96DE-01414FB207D8}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Commitments.Core.Tests", "tests\Commitments.Core.Tests\Commitments.Core.Tests.csproj", "{11111111-1111-1111-1111-111111111111}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Commitments.Infrastructure.Tests", "tests\Commitments.Infrastructure.Tests\Commitments.Infrastructure.Tests.csproj", "{22222222-2222-2222-2222-222222222222}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Commitments.Api.Tests", "tests\Commitments.Api.Tests\Commitments.Api.Tests.csproj", "{33333333-3333-3333-3333-333333333333}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -71,6 +79,42 @@ Global
 		{E7599E3E-576F-4D76-96DE-01414FB207D8}.Release|x64.Build.0 = Release|Any CPU
 		{E7599E3E-576F-4D76-96DE-01414FB207D8}.Release|x86.ActiveCfg = Release|Any CPU
 		{E7599E3E-576F-4D76-96DE-01414FB207D8}.Release|x86.Build.0 = Release|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Debug|x64.Build.0 = Debug|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Debug|x86.Build.0 = Debug|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Release|Any CPU.Build.0 = Release|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Release|x64.ActiveCfg = Release|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Release|x64.Build.0 = Release|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Release|x86.ActiveCfg = Release|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Release|x86.Build.0 = Release|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Debug|x64.Build.0 = Debug|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Debug|x86.Build.0 = Debug|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Release|Any CPU.Build.0 = Release|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Release|x64.ActiveCfg = Release|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Release|x64.Build.0 = Release|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Release|x86.ActiveCfg = Release|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Release|x86.Build.0 = Release|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Debug|x64.Build.0 = Debug|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Debug|x86.Build.0 = Debug|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Release|Any CPU.Build.0 = Release|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Release|x64.ActiveCfg = Release|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Release|x64.Build.0 = Release|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Release|x86.ActiveCfg = Release|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -80,6 +124,9 @@ Global
 		{757273B5-D255-430C-9823-F7CB58D757BA} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{0404A7B4-7E86-4CC2-B212-B91A8DEE1183} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{E7599E3E-576F-4D76-96DE-01414FB207D8} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{11111111-1111-1111-1111-111111111111} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
+		{22222222-2222-2222-2222-222222222222} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
+		{33333333-3333-3333-3333-333333333333} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D80DB4B0-7BFE-4AF3-B499-EC4FEFAC34C2}

--- a/tests/Commitments.Api.Tests/Commitments.Api.Tests.csproj
+++ b/tests/Commitments.Api.Tests/Commitments.Api.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Commitments.Api\Commitments.Api.csproj" />
+    <ProjectReference Include="..\..\src\Commitments.Core\Commitments.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Commitments.Api.Tests/Controllers/ActivityControllerTests.cs
+++ b/tests/Commitments.Api.Tests/Controllers/ActivityControllerTests.cs
@@ -1,0 +1,159 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Api.Controllers;
+using Commitments.Core.AggregateModel.ActivityAggregate;
+using Commitments.Core.AggregateModel.ActivityAggregate.Commands;
+using Commitments.Core.AggregateModel.ActivityAggregate.Queries;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using System.Security.Claims;
+using Xunit;
+
+namespace Commitments.Api.Tests.Controllers;
+
+public class ActivityControllerTests
+{
+    private readonly Mock<ISender> _mockSender;
+    private readonly Mock<IHttpContextAccessor> _mockHttpContextAccessor;
+    private readonly ActivityController _controller;
+    private readonly Guid _profileId = Guid.NewGuid();
+
+    public ActivityControllerTests()
+    {
+        _mockSender = new Mock<ISender>();
+        _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+
+        var claims = new List<Claim>
+        {
+            new Claim("ProfileId", _profileId.ToString())
+        };
+        var identity = new ClaimsIdentity(claims, "test");
+        var principal = new ClaimsPrincipal(identity);
+
+        var mockHttpContext = new Mock<HttpContext>();
+        mockHttpContext.Setup(c => c.User).Returns(principal);
+        _mockHttpContextAccessor.Setup(a => a.HttpContext).Returns(mockHttpContext.Object);
+
+        _controller = new ActivityController(_mockHttpContextAccessor.Object, _mockSender.Object);
+    }
+
+    [Fact]
+    public async Task Save_ShouldReturnSaveActivityResponse()
+    {
+        // Arrange
+        var request = new SaveActivityRequest
+        {
+            Activity = new ActivityDto
+            {
+                ActivityId = Guid.NewGuid(),
+                BehaviourId = Guid.NewGuid(),
+                PerformedOn = DateTime.UtcNow
+            }
+        };
+        var expectedResponse = new SaveActivityResponse
+        {
+            ActivityId = request.Activity.ActivityId
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<SaveActivityRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.Save(request);
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.ActivityId.Should().Be(expectedResponse.ActivityId);
+    }
+
+    [Fact]
+    public async Task Save_ShouldSetProfileIdFromHttpContext()
+    {
+        // Arrange
+        var request = new SaveActivityRequest
+        {
+            Activity = new ActivityDto
+            {
+                ActivityId = Guid.NewGuid(),
+                BehaviourId = Guid.NewGuid(),
+                PerformedOn = DateTime.UtcNow
+            }
+        };
+        var expectedResponse = new SaveActivityResponse
+        {
+            ActivityId = request.Activity.ActivityId
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<SaveActivityRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        await _controller.Save(request);
+
+        // Assert
+        request.Activity.ProfileId.Should().Be(_profileId);
+    }
+
+    [Fact]
+    public async Task Remove_ShouldCallSender()
+    {
+        // Arrange
+        var request = new RemoveActivityRequest
+        {
+            ActivityId = Guid.NewGuid()
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<RemoveActivityRequest>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _controller.Remove(request);
+
+        // Assert
+        _mockSender.Verify(s => s.Send(It.Is<RemoveActivityRequest>(r => r.ActivityId == request.ActivityId), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetById_ShouldReturnActivity()
+    {
+        // Arrange
+        var activityId = Guid.NewGuid();
+        var request = new GetActivityByIdRequest { ActivityId = activityId };
+        var expectedResponse = new GetActivityByIdResponse
+        {
+            Activity = new ActivityDto { ActivityId = activityId }
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<GetActivityByIdRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.GetById(request);
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.Activity.ActivityId.Should().Be(activityId);
+    }
+
+    [Fact]
+    public async Task Get_ShouldReturnAllActivities()
+    {
+        // Arrange
+        var expectedResponse = new GetActivitiesResponse
+        {
+            Activities = new List<ActivityDto>
+            {
+                new ActivityDto { ActivityId = Guid.NewGuid() },
+                new ActivityDto { ActivityId = Guid.NewGuid() }
+            }
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<GetActivitiesRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.Get();
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.Activities.Should().HaveCount(2);
+    }
+}

--- a/tests/Commitments.Api.Tests/Controllers/BehaviourControllerTests.cs
+++ b/tests/Commitments.Api.Tests/Controllers/BehaviourControllerTests.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Api.Controllers;
+using Commitments.Core.AggregateModel.BehaviourAggregate;
+using Commitments.Core.AggregateModel.BehaviourAggregate.Commands;
+using Commitments.Core.AggregateModel.BehaviourAggregate.Queries;
+using FluentAssertions;
+using MediatR;
+using Moq;
+using Xunit;
+
+namespace Commitments.Api.Tests.Controllers;
+
+public class BehaviourControllerTests
+{
+    private readonly Mock<ISender> _mockSender;
+    private readonly BehaviourController _controller;
+
+    public BehaviourControllerTests()
+    {
+        _mockSender = new Mock<ISender>();
+        _controller = new BehaviourController(_mockSender.Object);
+    }
+
+    [Fact]
+    public async Task Save_ShouldReturnSaveBehaviourResponse()
+    {
+        // Arrange
+        var request = new SaveBehaviourRequest
+        {
+            Behaviour = new BehaviourDto
+            {
+                BehaviourId = Guid.NewGuid(),
+                Name = "Test Behaviour",
+                BehaviourTypeId = Guid.NewGuid()
+            }
+        };
+        var expectedResponse = new SaveBehaviourResponse
+        {
+            BehaviourId = request.Behaviour.BehaviourId
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<SaveBehaviourRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.Save(request);
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.BehaviourId.Should().Be(expectedResponse.BehaviourId);
+    }
+
+    [Fact]
+    public async Task Remove_ShouldCallSender()
+    {
+        // Arrange
+        var request = new RemoveBehaviourRequest
+        {
+            BehaviourId = Guid.NewGuid()
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<RemoveBehaviourRequest>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _controller.Remove(request);
+
+        // Assert
+        _mockSender.Verify(s => s.Send(It.Is<RemoveBehaviourRequest>(r => r.BehaviourId == request.BehaviourId), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetById_ShouldReturnBehaviour()
+    {
+        // Arrange
+        var behaviourId = Guid.NewGuid();
+        var request = new GetBehaviourByIdRequest { BehaviourId = behaviourId };
+        var expectedResponse = new GetBehaviourByIdResponse
+        {
+            Behaviour = new BehaviourDto { BehaviourId = behaviourId, Name = "Test" }
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<GetBehaviourByIdRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.GetById(request);
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.Behaviour.BehaviourId.Should().Be(behaviourId);
+    }
+
+    [Fact]
+    public async Task Get_ShouldReturnAllBehaviours()
+    {
+        // Arrange
+        var expectedResponse = new GetBehavioursResponse
+        {
+            Behaviours = new List<BehaviourDto>
+            {
+                new BehaviourDto { BehaviourId = Guid.NewGuid(), Name = "Behaviour 1" },
+                new BehaviourDto { BehaviourId = Guid.NewGuid(), Name = "Behaviour 2" }
+            }
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<GetBehavioursRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.Get();
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.Behaviours.Should().HaveCount(2);
+    }
+}

--- a/tests/Commitments.Api.Tests/Controllers/BehaviourTypeControllerTests.cs
+++ b/tests/Commitments.Api.Tests/Controllers/BehaviourTypeControllerTests.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Api.Controllers;
+using Commitments.Core.AggregateModel.BehaviourTypeAggregate;
+using Commitments.Core.AggregateModel.BehaviourTypeAggregate.Commands;
+using Commitments.Core.AggregateModel.BehaviourTypeAggregate.Queries;
+using FluentAssertions;
+using MediatR;
+using Moq;
+using Xunit;
+
+namespace Commitments.Api.Tests.Controllers;
+
+public class BehaviourTypeControllerTests
+{
+    private readonly Mock<ISender> _mockSender;
+    private readonly BehaviourTypeController _controller;
+
+    public BehaviourTypeControllerTests()
+    {
+        _mockSender = new Mock<ISender>();
+        _controller = new BehaviourTypeController(_mockSender.Object);
+    }
+
+    [Fact]
+    public async Task Save_ShouldReturnSaveBehaviourTypeResponse()
+    {
+        // Arrange
+        var request = new SaveBehaviourTypeRequest
+        {
+            BehaviourType = new BehaviourTypeDto
+            {
+                BehaviourTypeId = Guid.NewGuid(),
+                Name = "Test Behaviour Type"
+            }
+        };
+        var expectedResponse = new SaveBehaviourTypeResponse
+        {
+            BehaviourTypeId = request.BehaviourType.BehaviourTypeId
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<SaveBehaviourTypeRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.Save(request);
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.BehaviourTypeId.Should().Be(expectedResponse.BehaviourTypeId);
+    }
+
+    [Fact]
+    public async Task Remove_ShouldCallSender()
+    {
+        // Arrange
+        var request = new RemoveBehaviourTypeRequest
+        {
+            BehaviourTypeId = Guid.NewGuid()
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<RemoveBehaviourTypeRequest>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _controller.Remove(request);
+
+        // Assert
+        _mockSender.Verify(s => s.Send(It.Is<RemoveBehaviourTypeRequest>(r => r.BehaviourTypeId == request.BehaviourTypeId), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetById_ShouldReturnBehaviourType()
+    {
+        // Arrange
+        var behaviourTypeId = Guid.NewGuid();
+        var request = new GetBehaviourTypeByIdRequest { BehaviourTypeId = behaviourTypeId };
+        var expectedResponse = new GetBehaviourTypeByIdResponse
+        {
+            BehaviourType = new BehaviourTypeDto { BehaviourTypeId = behaviourTypeId, Name = "Test" }
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<GetBehaviourTypeByIdRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.GetById(request);
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.BehaviourType.BehaviourTypeId.Should().Be(behaviourTypeId);
+    }
+
+    [Fact]
+    public async Task Get_ShouldReturnAllBehaviourTypes()
+    {
+        // Arrange
+        var expectedResponse = new GetBehaviourTypesResponse
+        {
+            BehaviourTypes = new List<BehaviourTypeDto>
+            {
+                new BehaviourTypeDto { BehaviourTypeId = Guid.NewGuid(), Name = "Type 1" },
+                new BehaviourTypeDto { BehaviourTypeId = Guid.NewGuid(), Name = "Type 2" }
+            }
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<GetBehaviourTypesRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.Get();
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.BehaviourTypes.Should().HaveCount(2);
+    }
+}

--- a/tests/Commitments.Api.Tests/Controllers/CardControllerTests.cs
+++ b/tests/Commitments.Api.Tests/Controllers/CardControllerTests.cs
@@ -1,0 +1,143 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Api.Controllers;
+using Commitments.Core.AggregateModel.CardAggregate;
+using Commitments.Core.AggregateModel.CardAggregate.Commands;
+using Commitments.Core.AggregateModel.CardAggregate.Queries;
+using FluentAssertions;
+using MediatR;
+using Moq;
+using Xunit;
+
+namespace Commitments.Api.Tests.Controllers;
+
+public class CardControllerTests
+{
+    private readonly Mock<ISender> _mockSender;
+    private readonly CardController _controller;
+
+    public CardControllerTests()
+    {
+        _mockSender = new Mock<ISender>();
+        _controller = new CardController(_mockSender.Object);
+    }
+
+    [Fact]
+    public async Task Create_ShouldReturnCreateCardResponse()
+    {
+        // Arrange
+        var request = new CreateCardRequest
+        {
+            Card = new CardDto
+            {
+                CardId = Guid.NewGuid(),
+                Name = "Test Card",
+                Description = "Test Description"
+            }
+        };
+        var expectedResponse = new CreateCardResponse
+        {
+            Card = request.Card
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<CreateCardRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.Create(request);
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.Card.CardId.Should().Be(request.Card.CardId);
+    }
+
+    [Fact]
+    public async Task Update_ShouldReturnUpdateCardResponse()
+    {
+        // Arrange
+        var request = new UpdateCardRequest
+        {
+            Card = new CardDto
+            {
+                CardId = Guid.NewGuid(),
+                Name = "Updated Card"
+            }
+        };
+        var expectedResponse = new UpdateCardResponse
+        {
+            Card = request.Card
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<UpdateCardRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.Update(request);
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.Card.Name.Should().Be("Updated Card");
+    }
+
+    [Fact]
+    public async Task Delete_ShouldCallSender()
+    {
+        // Arrange
+        var request = new DeleteCardRequest
+        {
+            CardId = Guid.NewGuid()
+        };
+        var expectedResponse = new DeleteCardResponse();
+        _mockSender.Setup(s => s.Send(It.IsAny<DeleteCardRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        await _controller.Delete(request);
+
+        // Assert
+        _mockSender.Verify(s => s.Send(It.Is<DeleteCardRequest>(r => r.CardId == request.CardId), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetById_ShouldReturnCard()
+    {
+        // Arrange
+        var cardId = Guid.NewGuid();
+        var request = new GetCardByIdRequest { CardId = cardId };
+        var expectedResponse = new GetCardByIdResponse
+        {
+            Card = new CardDto { CardId = cardId, Name = "Test Card" }
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<GetCardByIdRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.GetById(request);
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.Card.CardId.Should().Be(cardId);
+    }
+
+    [Fact]
+    public async Task Get_ShouldReturnAllCards()
+    {
+        // Arrange
+        var expectedResponse = new GetCardsResponse
+        {
+            Cards = new List<CardDto>
+            {
+                new CardDto { CardId = Guid.NewGuid(), Name = "Card 1" },
+                new CardDto { CardId = Guid.NewGuid(), Name = "Card 2" }
+            }
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<GetCardsRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.Get();
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.Cards.Should().HaveCount(2);
+    }
+}

--- a/tests/Commitments.Api.Tests/Controllers/CommitmentControllerTests.cs
+++ b/tests/Commitments.Api.Tests/Controllers/CommitmentControllerTests.cs
@@ -1,0 +1,202 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Api.Controllers;
+using Commitments.Core.AggregateModel.CommitmentAggregate;
+using Commitments.Core.AggregateModel.CommitmentAggregate.Commands;
+using Commitments.Core.AggregateModel.CommitmentAggregate.Queries;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using System.Security.Claims;
+using Xunit;
+
+namespace Commitments.Api.Tests.Controllers;
+
+public class CommitmentControllerTests
+{
+    private readonly Mock<ISender> _mockSender;
+    private readonly Mock<IHttpContextAccessor> _mockHttpContextAccessor;
+    private readonly CommitmentController _controller;
+    private readonly Guid _profileId = Guid.NewGuid();
+
+    public CommitmentControllerTests()
+    {
+        _mockSender = new Mock<ISender>();
+        _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+
+        var claims = new List<Claim>
+        {
+            new Claim("ProfileId", _profileId.ToString())
+        };
+        var identity = new ClaimsIdentity(claims, "test");
+        var principal = new ClaimsPrincipal(identity);
+
+        var mockHttpContext = new Mock<HttpContext>();
+        mockHttpContext.Setup(c => c.User).Returns(principal);
+        _mockHttpContextAccessor.Setup(a => a.HttpContext).Returns(mockHttpContext.Object);
+
+        _controller = new CommitmentController(_mockHttpContextAccessor.Object, _mockSender.Object);
+    }
+
+    [Fact]
+    public async Task Save_ShouldReturnSaveCommitmentResponse()
+    {
+        // Arrange
+        var request = new SaveCommitmentRequest
+        {
+            Commitment = new CommitmentDto
+            {
+                CommitmentId = Guid.NewGuid(),
+                BehaviourId = Guid.NewGuid()
+            }
+        };
+        var expectedResponse = new SaveCommitmentResponse
+        {
+            CommitmentId = request.Commitment.CommitmentId
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<SaveCommitmentRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.Save(request);
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.CommitmentId.Should().Be(expectedResponse.CommitmentId);
+    }
+
+    [Fact]
+    public async Task Save_ShouldSetProfileIdFromHttpContext()
+    {
+        // Arrange
+        var request = new SaveCommitmentRequest
+        {
+            Commitment = new CommitmentDto
+            {
+                CommitmentId = Guid.NewGuid(),
+                BehaviourId = Guid.NewGuid()
+            }
+        };
+        var expectedResponse = new SaveCommitmentResponse
+        {
+            CommitmentId = request.Commitment.CommitmentId
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<SaveCommitmentRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        await _controller.Save(request);
+
+        // Assert
+        request.Commitment.ProfileId.Should().Be(_profileId);
+    }
+
+    [Fact]
+    public async Task Remove_ShouldCallSender()
+    {
+        // Arrange
+        var request = new RemoveCommitmentRequest
+        {
+            CommitmentId = Guid.NewGuid()
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<RemoveCommitmentRequest>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _controller.Remove(request);
+
+        // Assert
+        _mockSender.Verify(s => s.Send(It.Is<RemoveCommitmentRequest>(r => r.CommitmentId == request.CommitmentId), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetById_ShouldReturnCommitment()
+    {
+        // Arrange
+        var commitmentId = Guid.NewGuid();
+        var request = new GetCommitmentByIdRequest { CommitmentId = commitmentId };
+        var expectedResponse = new GetCommitmentByIdResponse
+        {
+            Commitment = new CommitmentDto { CommitmentId = commitmentId }
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<GetCommitmentByIdRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.GetById(request);
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.Commitment.CommitmentId.Should().Be(commitmentId);
+    }
+
+    [Fact]
+    public async Task Get_ShouldReturnAllCommitments()
+    {
+        // Arrange
+        var expectedResponse = new GetCommitmentsResponse
+        {
+            Commitments = new List<CommitmentDto>
+            {
+                new CommitmentDto { CommitmentId = Guid.NewGuid() },
+                new CommitmentDto { CommitmentId = Guid.NewGuid() }
+            }
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<GetCommitmentsRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.Get();
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.Commitments.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task GetPersonal_ShouldReturnPersonalCommitments()
+    {
+        // Arrange
+        var expectedResponse = new GetPersonalCommitmentsResponse
+        {
+            Commitments = new List<CommitmentDto>
+            {
+                new CommitmentDto { CommitmentId = Guid.NewGuid(), ProfileId = _profileId }
+            }
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<GetPersonalCommitmentsRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.GetPersonal();
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.Commitments.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task GetDaily_ShouldReturnDailyCommitments()
+    {
+        // Arrange
+        var expectedResponse = new GetDailyCommitmentsResponse
+        {
+            Commitments = new List<CommitmentDto>
+            {
+                new CommitmentDto { CommitmentId = Guid.NewGuid() }
+            }
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<GetDailyCommitmentsRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.GetDaily();
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.Commitments.Should().HaveCount(1);
+    }
+}

--- a/tests/Commitments.Api.Tests/Controllers/DashboardControllerTests.cs
+++ b/tests/Commitments.Api.Tests/Controllers/DashboardControllerTests.cs
@@ -1,0 +1,181 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Api.Controllers;
+using Commitments.Core.AggregateModel.DashboardAggregate;
+using Commitments.Core.AggregateModel.DashboardAggregate.Commands;
+using Commitments.Core.AggregateModel.DashboardAggregate.Queries;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using System.Security.Claims;
+using Xunit;
+
+namespace Commitments.Api.Tests.Controllers;
+
+public class DashboardControllerTests
+{
+    private readonly Mock<ISender> _mockSender;
+    private readonly Mock<IHttpContextAccessor> _mockHttpContextAccessor;
+    private readonly DashboardController _controller;
+    private readonly Guid _profileId = Guid.NewGuid();
+
+    public DashboardControllerTests()
+    {
+        _mockSender = new Mock<ISender>();
+        _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+
+        var claims = new List<Claim>
+        {
+            new Claim("ProfileId", _profileId.ToString())
+        };
+        var identity = new ClaimsIdentity(claims, "test");
+        var principal = new ClaimsPrincipal(identity);
+
+        var mockHttpContext = new Mock<HttpContext>();
+        mockHttpContext.Setup(c => c.User).Returns(principal);
+        _mockHttpContextAccessor.Setup(a => a.HttpContext).Returns(mockHttpContext.Object);
+
+        _controller = new DashboardController(_mockHttpContextAccessor.Object, _mockSender.Object);
+    }
+
+    [Fact]
+    public async Task Create_ShouldReturnCreateDashboardResponse()
+    {
+        // Arrange
+        var request = new CreateDashboardRequest
+        {
+            Dashboard = new DashboardDto
+            {
+                DashboardId = Guid.NewGuid(),
+                Name = "Test Dashboard"
+            }
+        };
+        var expectedResponse = new CreateDashboardResponse
+        {
+            Dashboard = request.Dashboard
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<CreateDashboardRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.Create(request);
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.Dashboard.DashboardId.Should().Be(request.Dashboard.DashboardId);
+    }
+
+    [Fact]
+    public async Task Update_ShouldReturnUpdateDashboardResponse()
+    {
+        // Arrange
+        var request = new UpdateDashboardRequest
+        {
+            Dashboard = new DashboardDto
+            {
+                DashboardId = Guid.NewGuid(),
+                Name = "Updated Dashboard"
+            }
+        };
+        var expectedResponse = new UpdateDashboardResponse
+        {
+            Dashboard = request.Dashboard
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<UpdateDashboardRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.Update(request);
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.Dashboard.Name.Should().Be("Updated Dashboard");
+    }
+
+    [Fact]
+    public async Task Delete_ShouldCallSender()
+    {
+        // Arrange
+        var request = new DeleteDashboardRequest
+        {
+            DashboardId = Guid.NewGuid()
+        };
+        var expectedResponse = new DeleteDashboardResponse();
+        _mockSender.Setup(s => s.Send(It.IsAny<DeleteDashboardRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        await _controller.Delete(request);
+
+        // Assert
+        _mockSender.Verify(s => s.Send(It.Is<DeleteDashboardRequest>(r => r.DashboardId == request.DashboardId), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetById_ShouldReturnDashboard()
+    {
+        // Arrange
+        var dashboardId = Guid.NewGuid();
+        var request = new GetDashboardByIdRequest { DashboardId = dashboardId };
+        var expectedResponse = new GetDashboardByIdResponse
+        {
+            Dashboard = new DashboardDto { DashboardId = dashboardId, Name = "Test" }
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<GetDashboardByIdRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.GetById(request);
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.Dashboard.DashboardId.Should().Be(dashboardId);
+    }
+
+    [Fact]
+    public async Task Get_ShouldReturnAllDashboards()
+    {
+        // Arrange
+        var expectedResponse = new GetDashboardsResponse
+        {
+            Dashboards = new List<DashboardDto>
+            {
+                new DashboardDto { DashboardId = Guid.NewGuid(), Name = "Dashboard 1" },
+                new DashboardDto { DashboardId = Guid.NewGuid(), Name = "Dashboard 2" }
+            }
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<GetDashboardsRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.Get();
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.Dashboards.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task GetByCurrentUser_ShouldReturnDashboardsForCurrentUser()
+    {
+        // Arrange
+        var expectedResponse = new GetDashboardsByCurrentUserResponse
+        {
+            Dashboards = new List<DashboardDto>
+            {
+                new DashboardDto { DashboardId = Guid.NewGuid(), Name = "My Dashboard" }
+            }
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<GetDashboardsByCurrentUserRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.GetByCurrentUser();
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.Dashboards.Should().HaveCount(1);
+    }
+}

--- a/tests/Commitments.Api.Tests/Controllers/FrequencyControllerTests.cs
+++ b/tests/Commitments.Api.Tests/Controllers/FrequencyControllerTests.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Api.Controllers;
+using Commitments.Core.AggregateModel.FrequencyAggregate;
+using Commitments.Core.AggregateModel.FrequencyAggregate.Commands;
+using Commitments.Core.AggregateModel.FrequencyAggregate.Queries;
+using FluentAssertions;
+using MediatR;
+using Moq;
+using Xunit;
+
+namespace Commitments.Api.Tests.Controllers;
+
+public class FrequencyControllerTests
+{
+    private readonly Mock<ISender> _mockSender;
+    private readonly FrequencyController _controller;
+
+    public FrequencyControllerTests()
+    {
+        _mockSender = new Mock<ISender>();
+        _controller = new FrequencyController(_mockSender.Object);
+    }
+
+    [Fact]
+    public async Task Save_ShouldReturnSaveFrequencyResponse()
+    {
+        // Arrange
+        var request = new SaveFrequencyRequest
+        {
+            Frequency = new FrequencyDto
+            {
+                FrequencyId = Guid.NewGuid(),
+                FrequencyTypeId = Guid.NewGuid()
+            }
+        };
+        var expectedResponse = new SaveFrequencyResponse
+        {
+            FrequencyId = request.Frequency.FrequencyId
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<SaveFrequencyRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.Save(request);
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.FrequencyId.Should().Be(expectedResponse.FrequencyId);
+    }
+
+    [Fact]
+    public async Task Remove_ShouldCallSender()
+    {
+        // Arrange
+        var request = new RemoveFrequencyRequest
+        {
+            FrequencyId = Guid.NewGuid()
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<RemoveFrequencyRequest>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _controller.Remove(request);
+
+        // Assert
+        _mockSender.Verify(s => s.Send(It.Is<RemoveFrequencyRequest>(r => r.FrequencyId == request.FrequencyId), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetById_ShouldReturnFrequency()
+    {
+        // Arrange
+        var frequencyId = Guid.NewGuid();
+        var request = new GetFrequencyByIdRequest { FrequencyId = frequencyId };
+        var expectedResponse = new GetFrequencyByIdResponse
+        {
+            Frequency = new FrequencyDto { FrequencyId = frequencyId }
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<GetFrequencyByIdRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.GetById(request);
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.Frequency.FrequencyId.Should().Be(frequencyId);
+    }
+
+    [Fact]
+    public async Task Get_ShouldReturnAllFrequencies()
+    {
+        // Arrange
+        var expectedResponse = new GetFrequenciesResponse
+        {
+            Frequencies = new List<FrequencyDto>
+            {
+                new FrequencyDto { FrequencyId = Guid.NewGuid() },
+                new FrequencyDto { FrequencyId = Guid.NewGuid() }
+            }
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<GetFrequenciesRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.Get();
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.Frequencies.Should().HaveCount(2);
+    }
+}

--- a/tests/Commitments.Api.Tests/Controllers/FrequencyTypeControllerTests.cs
+++ b/tests/Commitments.Api.Tests/Controllers/FrequencyTypeControllerTests.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Api.Controllers;
+using Commitments.Core.AggregateModel.FrequencyTypeAggregate;
+using Commitments.Core.AggregateModel.FrequencyTypeAggregate.Commands;
+using Commitments.Core.AggregateModel.FrequencyTypeAggregate.Queries;
+using FluentAssertions;
+using MediatR;
+using Moq;
+using Xunit;
+
+namespace Commitments.Api.Tests.Controllers;
+
+public class FrequencyTypeControllerTests
+{
+    private readonly Mock<ISender> _mockSender;
+    private readonly FrequencyTypeController _controller;
+
+    public FrequencyTypeControllerTests()
+    {
+        _mockSender = new Mock<ISender>();
+        _controller = new FrequencyTypeController(_mockSender.Object);
+    }
+
+    [Fact]
+    public async Task Save_ShouldReturnSaveFrequencyTypeResponse()
+    {
+        // Arrange
+        var request = new SaveFrequencyTypeRequest
+        {
+            FrequencyType = new FrequencyTypeDto
+            {
+                FrequencyTypeId = Guid.NewGuid(),
+                Name = "Daily"
+            }
+        };
+        var expectedResponse = new SaveFrequencyTypeResponse
+        {
+            FrequencyTypeId = request.FrequencyType.FrequencyTypeId
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<SaveFrequencyTypeRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.Save(request);
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.FrequencyTypeId.Should().Be(expectedResponse.FrequencyTypeId);
+    }
+
+    [Fact]
+    public async Task Remove_ShouldCallSender()
+    {
+        // Arrange
+        var request = new RemoveFrequencyTypeRequest
+        {
+            FrequencyTypeId = Guid.NewGuid()
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<RemoveFrequencyTypeRequest>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _controller.Remove(request);
+
+        // Assert
+        _mockSender.Verify(s => s.Send(It.Is<RemoveFrequencyTypeRequest>(r => r.FrequencyTypeId == request.FrequencyTypeId), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetById_ShouldReturnFrequencyType()
+    {
+        // Arrange
+        var frequencyTypeId = Guid.NewGuid();
+        var request = new GetFrequencyTypeByIdRequest { FrequencyTypeId = frequencyTypeId };
+        var expectedResponse = new GetFrequencyTypeByIdResponse
+        {
+            FrequencyType = new FrequencyTypeDto { FrequencyTypeId = frequencyTypeId, Name = "Daily" }
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<GetFrequencyTypeByIdRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.GetById(request);
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.FrequencyType.FrequencyTypeId.Should().Be(frequencyTypeId);
+    }
+
+    [Fact]
+    public async Task Get_ShouldReturnAllFrequencyTypes()
+    {
+        // Arrange
+        var expectedResponse = new GetFrequencyTypesResponse
+        {
+            FrequencyTypes = new List<FrequencyTypeDto>
+            {
+                new FrequencyTypeDto { FrequencyTypeId = Guid.NewGuid(), Name = "Daily" },
+                new FrequencyTypeDto { FrequencyTypeId = Guid.NewGuid(), Name = "Weekly" }
+            }
+        };
+        _mockSender.Setup(s => s.Send(It.IsAny<GetFrequencyTypesRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.Get();
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.FrequencyTypes.Should().HaveCount(2);
+    }
+}

--- a/tests/Commitments.Core.Tests/AggregateModel/ActivityAggregate/ActivityTests.cs
+++ b/tests/Commitments.Core.Tests/AggregateModel/ActivityAggregate/ActivityTests.cs
@@ -1,0 +1,128 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Core.AggregateModel;
+using Commitments.Core.AggregateModel.ActivityAggregate;
+using Commitments.Core.AggregateModel.BehaviourAggregate;
+using FluentAssertions;
+using Xunit;
+
+namespace Commitments.Core.Tests.AggregateModel.ActivityAggregate;
+
+public class ActivityTests
+{
+    [Fact]
+    public void Activity_ShouldSetActivityId()
+    {
+        // Arrange
+        var activity = new Activity();
+        var id = Guid.NewGuid();
+
+        // Act
+        activity.ActivityId = id;
+
+        // Assert
+        activity.ActivityId.Should().Be(id);
+    }
+
+    [Fact]
+    public void Activity_ShouldSetProfileId()
+    {
+        // Arrange
+        var activity = new Activity();
+        var profileId = Guid.NewGuid();
+
+        // Act
+        activity.ProfileId = profileId;
+
+        // Assert
+        activity.ProfileId.Should().Be(profileId);
+    }
+
+    [Fact]
+    public void Activity_ShouldSetBehaviourId()
+    {
+        // Arrange
+        var activity = new Activity();
+        var behaviourId = Guid.NewGuid();
+
+        // Act
+        activity.BehaviourId = behaviourId;
+
+        // Assert
+        activity.BehaviourId.Should().Be(behaviourId);
+    }
+
+    [Fact]
+    public void Activity_ShouldSetPerformedOn()
+    {
+        // Arrange
+        var activity = new Activity();
+        var performedOn = DateTime.UtcNow;
+
+        // Act
+        activity.PerformedOn = performedOn;
+
+        // Assert
+        activity.PerformedOn.Should().Be(performedOn);
+    }
+
+    [Fact]
+    public void Activity_ShouldSetDescription()
+    {
+        // Arrange
+        var activity = new Activity();
+        var description = "Test activity description";
+
+        // Act
+        activity.Description = description;
+
+        // Assert
+        activity.Description.Should().Be(description);
+    }
+
+    [Fact]
+    public void Activity_ShouldSetProfile()
+    {
+        // Arrange
+        var activity = new Activity();
+        var profile = new Profile { ProfileId = Guid.NewGuid() };
+
+        // Act
+        activity.Profile = profile;
+
+        // Assert
+        activity.Profile.Should().Be(profile);
+    }
+
+    [Fact]
+    public void Activity_ShouldSetBehaviour()
+    {
+        // Arrange
+        var activity = new Activity();
+        var behaviour = new Behaviour { BehaviourId = Guid.NewGuid() };
+
+        // Act
+        activity.Behaviour = behaviour;
+
+        // Assert
+        activity.Behaviour.Should().Be(behaviour);
+    }
+
+    [Fact]
+    public void Activity_ShouldInheritFromBaseEntity()
+    {
+        // Arrange & Act
+        var activity = new Activity();
+        var now = DateTime.UtcNow;
+
+        activity.CreatedOn = now;
+        activity.LastModifiedOn = now;
+        activity.IsDeleted = true;
+
+        // Assert
+        activity.CreatedOn.Should().Be(now);
+        activity.LastModifiedOn.Should().Be(now);
+        activity.IsDeleted.Should().BeTrue();
+    }
+}

--- a/tests/Commitments.Core.Tests/AggregateModel/BaseEntityTests.cs
+++ b/tests/Commitments.Core.Tests/AggregateModel/BaseEntityTests.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Core.AggregateModel;
+using FluentAssertions;
+using Xunit;
+
+namespace Commitments.Core.Tests.AggregateModel;
+
+public class BaseEntityTests
+{
+    [Fact]
+    public void BaseEntity_ShouldHaveDefaultValues()
+    {
+        // Arrange & Act
+        var entity = new TestEntity();
+
+        // Assert
+        entity.CreatedOn.Should().Be(default);
+        entity.LastModifiedOn.Should().Be(default);
+        entity.IsDeleted.Should().BeFalse();
+    }
+
+    [Fact]
+    public void BaseEntity_ShouldSetCreatedOn()
+    {
+        // Arrange
+        var entity = new TestEntity();
+        var createdDate = DateTime.UtcNow;
+
+        // Act
+        entity.CreatedOn = createdDate;
+
+        // Assert
+        entity.CreatedOn.Should().Be(createdDate);
+    }
+
+    [Fact]
+    public void BaseEntity_ShouldSetLastModifiedOn()
+    {
+        // Arrange
+        var entity = new TestEntity();
+        var modifiedDate = DateTime.UtcNow;
+
+        // Act
+        entity.LastModifiedOn = modifiedDate;
+
+        // Assert
+        entity.LastModifiedOn.Should().Be(modifiedDate);
+    }
+
+    [Fact]
+    public void BaseEntity_ShouldSetIsDeleted()
+    {
+        // Arrange
+        var entity = new TestEntity();
+
+        // Act
+        entity.IsDeleted = true;
+
+        // Assert
+        entity.IsDeleted.Should().BeTrue();
+    }
+
+    private class TestEntity : BaseEntity
+    {
+    }
+}

--- a/tests/Commitments.Core.Tests/AggregateModel/BehaviourAggregate/BehaviourDtoTests.cs
+++ b/tests/Commitments.Core.Tests/AggregateModel/BehaviourAggregate/BehaviourDtoTests.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Core.AggregateModel.BehaviourAggregate;
+using Commitments.Core.AggregateModel.BehaviourTypeAggregate;
+using FluentAssertions;
+using Xunit;
+
+namespace Commitments.Core.Tests.AggregateModel.BehaviourAggregate;
+
+public class BehaviourDtoTests
+{
+    [Fact]
+    public void FromBehaviour_ShouldMapAllProperties()
+    {
+        // Arrange
+        var behaviourType = new BehaviourType
+        {
+            BehaviourTypeId = Guid.NewGuid(),
+            Name = "Test Behaviour Type"
+        };
+
+        var behaviour = new Behaviour
+        {
+            BehaviourId = Guid.NewGuid(),
+            Name = "Test Behaviour",
+            Slug = "test-behaviour",
+            Description = "A test behaviour",
+            BehaviourTypeId = behaviourType.BehaviourTypeId,
+            BehaviourType = behaviourType
+        };
+
+        // Act
+        var dto = BehaviourDto.FromBehaviour(behaviour);
+
+        // Assert
+        dto.BehaviourId.Should().Be(behaviour.BehaviourId);
+        dto.Name.Should().Be(behaviour.Name);
+        dto.Slug.Should().Be(behaviour.Slug);
+        dto.Description.Should().Be(behaviour.Description);
+        dto.BehaviourTypeId.Should().Be(behaviour.BehaviourTypeId);
+        dto.BehaviourType.Should().NotBeNull();
+        dto.BehaviourType.Name.Should().Be(behaviourType.Name);
+    }
+
+    [Fact]
+    public void BehaviourDto_ShouldSetProperties()
+    {
+        // Arrange
+        var dto = new BehaviourDto();
+        var behaviourId = Guid.NewGuid();
+        var behaviourTypeId = Guid.NewGuid();
+        var name = "Test Name";
+        var slug = "test-slug";
+        var description = "Test Description";
+
+        // Act
+        dto.BehaviourId = behaviourId;
+        dto.BehaviourTypeId = behaviourTypeId;
+        dto.Name = name;
+        dto.Slug = slug;
+        dto.Description = description;
+        dto.IsDesired = true;
+
+        // Assert
+        dto.BehaviourId.Should().Be(behaviourId);
+        dto.BehaviourTypeId.Should().Be(behaviourTypeId);
+        dto.Name.Should().Be(name);
+        dto.Slug.Should().Be(slug);
+        dto.Description.Should().Be(description);
+        dto.IsDesired.Should().BeTrue();
+    }
+}

--- a/tests/Commitments.Core.Tests/AggregateModel/BehaviourAggregate/BehaviourTests.cs
+++ b/tests/Commitments.Core.Tests/AggregateModel/BehaviourAggregate/BehaviourTests.cs
@@ -1,0 +1,144 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Core.AggregateModel.BehaviourAggregate;
+using Commitments.Core.AggregateModel.BehaviourTypeAggregate;
+using Commitments.Core.AggregateModel.CommitmentAggregate;
+using FluentAssertions;
+using Xunit;
+
+namespace Commitments.Core.Tests.AggregateModel.BehaviourAggregate;
+
+public class BehaviourTests
+{
+    [Fact]
+    public void Behaviour_ShouldInitializeWithEmptyCommitmentsCollection()
+    {
+        // Arrange & Act
+        var behaviour = new Behaviour();
+
+        // Assert
+        behaviour.Commitments.Should().NotBeNull();
+        behaviour.Commitments.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Behaviour_ShouldSetBehaviourId()
+    {
+        // Arrange
+        var behaviour = new Behaviour();
+        var id = Guid.NewGuid();
+
+        // Act
+        behaviour.BehaviourId = id;
+
+        // Assert
+        behaviour.BehaviourId.Should().Be(id);
+    }
+
+    [Fact]
+    public void Behaviour_ShouldSetName()
+    {
+        // Arrange
+        var behaviour = new Behaviour();
+        var name = "Test Behaviour";
+
+        // Act
+        behaviour.Name = name;
+
+        // Assert
+        behaviour.Name.Should().Be(name);
+    }
+
+    [Fact]
+    public void Behaviour_ShouldSetSlug()
+    {
+        // Arrange
+        var behaviour = new Behaviour();
+        var slug = "test-behaviour";
+
+        // Act
+        behaviour.Slug = slug;
+
+        // Assert
+        behaviour.Slug.Should().Be(slug);
+    }
+
+    [Fact]
+    public void Behaviour_ShouldSetDescription()
+    {
+        // Arrange
+        var behaviour = new Behaviour();
+        var description = "A test behaviour description";
+
+        // Act
+        behaviour.Description = description;
+
+        // Assert
+        behaviour.Description.Should().Be(description);
+    }
+
+    [Fact]
+    public void Behaviour_ShouldSetBehaviourTypeId()
+    {
+        // Arrange
+        var behaviour = new Behaviour();
+        var behaviourTypeId = Guid.NewGuid();
+
+        // Act
+        behaviour.BehaviourTypeId = behaviourTypeId;
+
+        // Assert
+        behaviour.BehaviourTypeId.Should().Be(behaviourTypeId);
+    }
+
+    [Fact]
+    public void Behaviour_ShouldSetBehaviourType()
+    {
+        // Arrange
+        var behaviour = new Behaviour();
+        var behaviourType = new BehaviourType
+        {
+            BehaviourTypeId = Guid.NewGuid(),
+            Name = "Test Type"
+        };
+
+        // Act
+        behaviour.BehaviourType = behaviourType;
+
+        // Assert
+        behaviour.BehaviourType.Should().Be(behaviourType);
+    }
+
+    [Fact]
+    public void Behaviour_ShouldAddCommitment()
+    {
+        // Arrange
+        var behaviour = new Behaviour();
+        var commitment = new Commitment { CommitmentId = Guid.NewGuid() };
+
+        // Act
+        behaviour.Commitments.Add(commitment);
+
+        // Assert
+        behaviour.Commitments.Should().HaveCount(1);
+        behaviour.Commitments.Should().Contain(commitment);
+    }
+
+    [Fact]
+    public void Behaviour_ShouldInheritFromBaseEntity()
+    {
+        // Arrange & Act
+        var behaviour = new Behaviour();
+        var now = DateTime.UtcNow;
+
+        behaviour.CreatedOn = now;
+        behaviour.LastModifiedOn = now;
+        behaviour.IsDeleted = true;
+
+        // Assert
+        behaviour.CreatedOn.Should().Be(now);
+        behaviour.LastModifiedOn.Should().Be(now);
+        behaviour.IsDeleted.Should().BeTrue();
+    }
+}

--- a/tests/Commitments.Core.Tests/AggregateModel/BehaviourTypeAggregate/BehaviourTypeDtoTests.cs
+++ b/tests/Commitments.Core.Tests/AggregateModel/BehaviourTypeAggregate/BehaviourTypeDtoTests.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Core.AggregateModel.BehaviourTypeAggregate;
+using FluentAssertions;
+using Xunit;
+
+namespace Commitments.Core.Tests.AggregateModel.BehaviourTypeAggregate;
+
+public class BehaviourTypeDtoTests
+{
+    [Fact]
+    public void FromBehaviourType_ShouldMapAllProperties()
+    {
+        // Arrange
+        var behaviourType = new BehaviourType
+        {
+            BehaviourTypeId = Guid.NewGuid(),
+            Name = "Test Behaviour Type"
+        };
+
+        // Act
+        var dto = BehaviourTypeDto.FromBehaviourType(behaviourType);
+
+        // Assert
+        dto.BehaviourTypeId.Should().Be(behaviourType.BehaviourTypeId);
+        dto.Name.Should().Be(behaviourType.Name);
+    }
+
+    [Fact]
+    public void BehaviourTypeDto_ShouldSetProperties()
+    {
+        // Arrange
+        var dto = new BehaviourTypeDto();
+        var behaviourTypeId = Guid.NewGuid();
+        var name = "Test Name";
+
+        // Act
+        dto.BehaviourTypeId = behaviourTypeId;
+        dto.Name = name;
+
+        // Assert
+        dto.BehaviourTypeId.Should().Be(behaviourTypeId);
+        dto.Name.Should().Be(name);
+    }
+}

--- a/tests/Commitments.Core.Tests/AggregateModel/BehaviourTypeAggregate/BehaviourTypeTests.cs
+++ b/tests/Commitments.Core.Tests/AggregateModel/BehaviourTypeAggregate/BehaviourTypeTests.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Core.AggregateModel.BehaviourAggregate;
+using Commitments.Core.AggregateModel.BehaviourTypeAggregate;
+using FluentAssertions;
+using Xunit;
+
+namespace Commitments.Core.Tests.AggregateModel.BehaviourTypeAggregate;
+
+public class BehaviourTypeTests
+{
+    [Fact]
+    public void BehaviourType_ShouldInitializeWithEmptyBehavioursCollection()
+    {
+        // Arrange & Act
+        var behaviourType = new BehaviourType();
+
+        // Assert
+        behaviourType.Behaviours.Should().NotBeNull();
+        behaviourType.Behaviours.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BehaviourType_ShouldSetBehaviourTypeId()
+    {
+        // Arrange
+        var behaviourType = new BehaviourType();
+        var id = Guid.NewGuid();
+
+        // Act
+        behaviourType.BehaviourTypeId = id;
+
+        // Assert
+        behaviourType.BehaviourTypeId.Should().Be(id);
+    }
+
+    [Fact]
+    public void BehaviourType_ShouldSetName()
+    {
+        // Arrange
+        var behaviourType = new BehaviourType();
+        var name = "Test Behaviour Type";
+
+        // Act
+        behaviourType.Name = name;
+
+        // Assert
+        behaviourType.Name.Should().Be(name);
+    }
+
+    [Fact]
+    public void BehaviourType_ShouldAddBehaviour()
+    {
+        // Arrange
+        var behaviourType = new BehaviourType();
+        var behaviour = new Behaviour { BehaviourId = Guid.NewGuid(), Name = "Test" };
+
+        // Act
+        behaviourType.Behaviours.Add(behaviour);
+
+        // Assert
+        behaviourType.Behaviours.Should().HaveCount(1);
+        behaviourType.Behaviours.Should().Contain(behaviour);
+    }
+
+    [Fact]
+    public void BehaviourType_ShouldInheritFromBaseEntity()
+    {
+        // Arrange & Act
+        var behaviourType = new BehaviourType();
+        var now = DateTime.UtcNow;
+
+        behaviourType.CreatedOn = now;
+        behaviourType.LastModifiedOn = now;
+        behaviourType.IsDeleted = true;
+
+        // Assert
+        behaviourType.CreatedOn.Should().Be(now);
+        behaviourType.LastModifiedOn.Should().Be(now);
+        behaviourType.IsDeleted.Should().BeTrue();
+    }
+}

--- a/tests/Commitments.Core.Tests/AggregateModel/CardAggregate/CardTests.cs
+++ b/tests/Commitments.Core.Tests/AggregateModel/CardAggregate/CardTests.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Core.AggregateModel.CardAggregate;
+using FluentAssertions;
+using Xunit;
+
+namespace Commitments.Core.Tests.AggregateModel.CardAggregate;
+
+public class CardTests
+{
+    [Fact]
+    public void Card_ShouldSetCardId()
+    {
+        // Arrange
+        var card = new Card();
+        var id = Guid.NewGuid();
+
+        // Act
+        card.CardId = id;
+
+        // Assert
+        card.CardId.Should().Be(id);
+    }
+
+    [Fact]
+    public void Card_ShouldSetName()
+    {
+        // Arrange
+        var card = new Card();
+        var name = "Test Card";
+
+        // Act
+        card.Name = name;
+
+        // Assert
+        card.Name.Should().Be(name);
+    }
+
+    [Fact]
+    public void Card_ShouldSetDescription()
+    {
+        // Arrange
+        var card = new Card();
+        var description = "This is a test card description";
+
+        // Act
+        card.Description = description;
+
+        // Assert
+        card.Description.Should().Be(description);
+    }
+
+    [Fact]
+    public void Card_ShouldAllowNullName()
+    {
+        // Arrange
+        var card = new Card();
+
+        // Act
+        card.Name = null!;
+
+        // Assert
+        card.Name.Should().BeNull();
+    }
+
+    [Fact]
+    public void Card_ShouldAllowNullDescription()
+    {
+        // Arrange
+        var card = new Card();
+
+        // Act
+        card.Description = null!;
+
+        // Assert
+        card.Description.Should().BeNull();
+    }
+
+    [Fact]
+    public void Card_ShouldSetAllProperties()
+    {
+        // Arrange
+        var card = new Card();
+        var id = Guid.NewGuid();
+        var name = "Test Card";
+        var description = "Test Description";
+
+        // Act
+        card.CardId = id;
+        card.Name = name;
+        card.Description = description;
+
+        // Assert
+        card.CardId.Should().Be(id);
+        card.Name.Should().Be(name);
+        card.Description.Should().Be(description);
+    }
+}

--- a/tests/Commitments.Core.Tests/AggregateModel/CommitmentAggregate/Commands/RemoveCommitmentTests.cs
+++ b/tests/Commitments.Core.Tests/AggregateModel/CommitmentAggregate/Commands/RemoveCommitmentTests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Core.AggregateModel.CommitmentAggregate.Commands;
+using FluentAssertions;
+using Xunit;
+
+namespace Commitments.Core.Tests.AggregateModel.CommitmentAggregate.Commands;
+
+public class RemoveCommitmentTests
+{
+    [Fact]
+    public void RemoveCommitmentCommandValidator_ShouldPassWhenCommitmentIdIsValid()
+    {
+        // Arrange
+        var validator = new RemoveCommitmentCommandValidator();
+        var request = new RemoveCommitmentRequest
+        {
+            CommitmentId = Guid.NewGuid()
+        };
+
+        // Act
+        var result = validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void RemoveCommitmentCommandValidator_ShouldFailWhenCommitmentIdIsDefault()
+    {
+        // Arrange
+        var validator = new RemoveCommitmentCommandValidator();
+        var request = new RemoveCommitmentRequest
+        {
+            CommitmentId = default
+        };
+
+        // Act
+        var result = validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void RemoveCommitmentRequest_ShouldSetCommitmentId()
+    {
+        // Arrange
+        var request = new RemoveCommitmentRequest();
+        var commitmentId = Guid.NewGuid();
+
+        // Act
+        request.CommitmentId = commitmentId;
+
+        // Assert
+        request.CommitmentId.Should().Be(commitmentId);
+    }
+}

--- a/tests/Commitments.Core.Tests/AggregateModel/CommitmentAggregate/Commands/SaveCommitmentTests.cs
+++ b/tests/Commitments.Core.Tests/AggregateModel/CommitmentAggregate/Commands/SaveCommitmentTests.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Core.AggregateModel.CommitmentAggregate;
+using Commitments.Core.AggregateModel.CommitmentAggregate.Commands;
+using Commitments.Core.Tests.Helpers;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Commitments.Core.Tests.AggregateModel.CommitmentAggregate.Commands;
+
+public class SaveCommitmentTests
+{
+    [Fact]
+    public void SaveCommitmentCommandValidator_ShouldPassWhenCommitmentIdIsSet()
+    {
+        // Arrange
+        var validator = new SaveCommitmentCommandValidator();
+        var request = new SaveCommitmentRequest
+        {
+            Commitment = new CommitmentDto
+            {
+                CommitmentId = Guid.NewGuid()
+            }
+        };
+
+        // Act
+        var result = validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SaveCommitmentCommandValidator_ShouldFailWhenCommitmentIdIsNotSet()
+    {
+        // Arrange
+        var validator = new SaveCommitmentCommandValidator();
+        var request = new SaveCommitmentRequest
+        {
+            Commitment = new CommitmentDto
+            {
+                CommitmentId = default
+            }
+        };
+
+        // Act
+        var result = validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SaveCommitmentCommandHandler_ShouldCreateNewCommitment()
+    {
+        // Arrange
+        var mockContext = MockDbContextFactory.Create();
+        var commitments = new List<Commitment>();
+        var mockDbSet = MockDbContextFactory.CreateMockDbSet(commitments);
+        mockContext.Setup(c => c.Commitments).Returns(mockDbSet.Object);
+
+        var handler = new SaveCommitmentCommandHandler(mockContext.Object);
+        var request = new SaveCommitmentRequest
+        {
+            Commitment = new CommitmentDto
+            {
+                CommitmentId = Guid.NewGuid(),
+                BehaviourId = Guid.NewGuid(),
+                ProfileId = Guid.NewGuid()
+            }
+        };
+
+        // Act
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        mockContext.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public void SaveCommitmentRequest_ShouldSetCommitment()
+    {
+        // Arrange
+        var request = new SaveCommitmentRequest();
+        var commitment = new CommitmentDto { CommitmentId = Guid.NewGuid() };
+
+        // Act
+        request.Commitment = commitment;
+
+        // Assert
+        request.Commitment.Should().Be(commitment);
+    }
+
+    [Fact]
+    public void SaveCommitmentResponse_ShouldSetCommitmentId()
+    {
+        // Arrange
+        var response = new SaveCommitmentResponse();
+        var commitmentId = Guid.NewGuid();
+
+        // Act
+        response.CommitmentId = commitmentId;
+
+        // Assert
+        response.CommitmentId.Should().Be(commitmentId);
+    }
+}

--- a/tests/Commitments.Core.Tests/AggregateModel/CommitmentAggregate/CommitmentDtoTests.cs
+++ b/tests/Commitments.Core.Tests/AggregateModel/CommitmentAggregate/CommitmentDtoTests.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Core.AggregateModel.BehaviourAggregate;
+using Commitments.Core.AggregateModel.BehaviourTypeAggregate;
+using Commitments.Core.AggregateModel.CommitmentAggregate;
+using Commitments.Core.AggregateModel.FrequencyAggregate;
+using Commitments.Core.AggregateModel.FrequencyTypeAggregate;
+using FluentAssertions;
+using Xunit;
+
+namespace Commitments.Core.Tests.AggregateModel.CommitmentAggregate;
+
+public class CommitmentDtoTests
+{
+    [Fact]
+    public void CommitmentDto_ShouldInitializeWithEmptyCommitmentFrequencies()
+    {
+        // Arrange & Act
+        var dto = new CommitmentDto();
+
+        // Assert
+        dto.CommitmentFrequencies.Should().NotBeNull();
+        dto.CommitmentFrequencies.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FromCommitment_ShouldMapAllProperties()
+    {
+        // Arrange
+        var behaviourType = new BehaviourType
+        {
+            BehaviourTypeId = Guid.NewGuid(),
+            Name = "Test Behaviour Type"
+        };
+
+        var behaviour = new Behaviour
+        {
+            BehaviourId = Guid.NewGuid(),
+            Name = "Test Behaviour",
+            Slug = "test-behaviour",
+            Description = "A test behaviour",
+            BehaviourTypeId = behaviourType.BehaviourTypeId,
+            BehaviourType = behaviourType
+        };
+
+        var frequencyType = new FrequencyType
+        {
+            FrequencyTypeId = Guid.NewGuid(),
+            Name = "Daily"
+        };
+
+        var frequency = new Frequency
+        {
+            FrequencyId = Guid.NewGuid(),
+            FrequencyTypeId = frequencyType.FrequencyTypeId,
+            FrequencyType = frequencyType,
+            IsDesirable = true
+        };
+
+        var commitment = new Commitment
+        {
+            CommitmentId = Guid.NewGuid(),
+            BehaviourId = behaviour.BehaviourId,
+            ProfileId = Guid.NewGuid(),
+            Behaviour = behaviour
+        };
+
+        commitment.CommitmentFrequencies.Add(new CommitmentFrequency
+        {
+            CommitmentFrequencyId = Guid.NewGuid(),
+            CommitmentId = commitment.CommitmentId,
+            FrequencyId = frequency.FrequencyId,
+            Frequency = frequency
+        });
+
+        // Act
+        var dto = CommitmentDto.FromCommitment(commitment);
+
+        // Assert
+        dto.CommitmentId.Should().Be(commitment.CommitmentId);
+        dto.BehaviourId.Should().Be(commitment.BehaviourId);
+        dto.ProfileId.Should().Be(commitment.ProfileId);
+        dto.Behaviour.Should().NotBeNull();
+        dto.Behaviour.Name.Should().Be(behaviour.Name);
+        dto.CommitmentFrequencies.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void CommitmentDto_ShouldSetProperties()
+    {
+        // Arrange
+        var dto = new CommitmentDto();
+        var commitmentId = Guid.NewGuid();
+        var behaviourId = Guid.NewGuid();
+        var profileId = Guid.NewGuid();
+
+        // Act
+        dto.CommitmentId = commitmentId;
+        dto.BehaviourId = behaviourId;
+        dto.ProfileId = profileId;
+
+        // Assert
+        dto.CommitmentId.Should().Be(commitmentId);
+        dto.BehaviourId.Should().Be(behaviourId);
+        dto.ProfileId.Should().Be(profileId);
+    }
+}

--- a/tests/Commitments.Core.Tests/AggregateModel/CommitmentAggregate/CommitmentFrequencyDtoTests.cs
+++ b/tests/Commitments.Core.Tests/AggregateModel/CommitmentAggregate/CommitmentFrequencyDtoTests.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Core.AggregateModel.CommitmentAggregate;
+using Commitments.Core.AggregateModel.FrequencyAggregate;
+using Commitments.Core.AggregateModel.FrequencyTypeAggregate;
+using FluentAssertions;
+using Xunit;
+
+namespace Commitments.Core.Tests.AggregateModel.CommitmentAggregate;
+
+public class CommitmentFrequencyDtoTests
+{
+    [Fact]
+    public void FromCommitmentFrequency_ShouldMapAllProperties()
+    {
+        // Arrange
+        var frequencyType = new FrequencyType
+        {
+            FrequencyTypeId = Guid.NewGuid(),
+            Name = "Daily"
+        };
+
+        var frequency = new Frequency
+        {
+            FrequencyId = Guid.NewGuid(),
+            FrequencyTypeId = frequencyType.FrequencyTypeId,
+            FrequencyType = frequencyType,
+            IsDesirable = true
+        };
+
+        var commitmentFrequency = new CommitmentFrequency
+        {
+            CommitmentFrequencyId = Guid.NewGuid(),
+            FrequencyId = frequency.FrequencyId,
+            Frequency = frequency
+        };
+
+        // Act
+        var dto = CommitmentFrequencyDto.FromCommitmentFrequency(commitmentFrequency);
+
+        // Assert
+        dto.CommitmentFrequencyId.Should().Be(commitmentFrequency.CommitmentFrequencyId);
+        dto.FrequencyId.Should().Be(commitmentFrequency.FrequencyId);
+        dto.Frequency.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void CommitmentFrequencyDto_ShouldSetProperties()
+    {
+        // Arrange
+        var dto = new CommitmentFrequencyDto();
+        var commitmentFrequencyId = Guid.NewGuid();
+        var frequencyId = Guid.NewGuid();
+        var name = "Test Name";
+
+        // Act
+        dto.CommitmentFrequencyId = commitmentFrequencyId;
+        dto.FrequencyId = frequencyId;
+        dto.Name = name;
+
+        // Assert
+        dto.CommitmentFrequencyId.Should().Be(commitmentFrequencyId);
+        dto.FrequencyId.Should().Be(frequencyId);
+        dto.Name.Should().Be(name);
+    }
+}

--- a/tests/Commitments.Core.Tests/AggregateModel/CommitmentAggregate/CommitmentFrequencyTests.cs
+++ b/tests/Commitments.Core.Tests/AggregateModel/CommitmentAggregate/CommitmentFrequencyTests.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Core.AggregateModel.CommitmentAggregate;
+using Commitments.Core.AggregateModel.FrequencyAggregate;
+using FluentAssertions;
+using Xunit;
+
+namespace Commitments.Core.Tests.AggregateModel.CommitmentAggregate;
+
+public class CommitmentFrequencyTests
+{
+    [Fact]
+    public void CommitmentFrequency_ShouldSetCommitmentFrequencyId()
+    {
+        // Arrange
+        var commitmentFrequency = new CommitmentFrequency();
+        var id = Guid.NewGuid();
+
+        // Act
+        commitmentFrequency.CommitmentFrequencyId = id;
+
+        // Assert
+        commitmentFrequency.CommitmentFrequencyId.Should().Be(id);
+    }
+
+    [Fact]
+    public void CommitmentFrequency_ShouldSetCommitmentId()
+    {
+        // Arrange
+        var commitmentFrequency = new CommitmentFrequency();
+        var commitmentId = Guid.NewGuid();
+
+        // Act
+        commitmentFrequency.CommitmentId = commitmentId;
+
+        // Assert
+        commitmentFrequency.CommitmentId.Should().Be(commitmentId);
+    }
+
+    [Fact]
+    public void CommitmentFrequency_ShouldSetFrequencyId()
+    {
+        // Arrange
+        var commitmentFrequency = new CommitmentFrequency();
+        var frequencyId = Guid.NewGuid();
+
+        // Act
+        commitmentFrequency.FrequencyId = frequencyId;
+
+        // Assert
+        commitmentFrequency.FrequencyId.Should().Be(frequencyId);
+    }
+
+    [Fact]
+    public void CommitmentFrequency_ShouldAllowNullCommitmentId()
+    {
+        // Arrange
+        var commitmentFrequency = new CommitmentFrequency();
+
+        // Act
+        commitmentFrequency.CommitmentId = null;
+
+        // Assert
+        commitmentFrequency.CommitmentId.Should().BeNull();
+    }
+
+    [Fact]
+    public void CommitmentFrequency_ShouldAllowNullFrequencyId()
+    {
+        // Arrange
+        var commitmentFrequency = new CommitmentFrequency();
+
+        // Act
+        commitmentFrequency.FrequencyId = null;
+
+        // Assert
+        commitmentFrequency.FrequencyId.Should().BeNull();
+    }
+
+    [Fact]
+    public void CommitmentFrequency_ShouldSetCommitmentNavigation()
+    {
+        // Arrange
+        var commitmentFrequency = new CommitmentFrequency();
+        var commitment = new Commitment { CommitmentId = Guid.NewGuid() };
+
+        // Act
+        commitmentFrequency.Commitment = commitment;
+
+        // Assert
+        commitmentFrequency.Commitment.Should().Be(commitment);
+    }
+
+    [Fact]
+    public void CommitmentFrequency_ShouldSetFrequencyNavigation()
+    {
+        // Arrange
+        var commitmentFrequency = new CommitmentFrequency();
+        var frequency = new Frequency { FrequencyId = Guid.NewGuid() };
+
+        // Act
+        commitmentFrequency.Frequency = frequency;
+
+        // Assert
+        commitmentFrequency.Frequency.Should().Be(frequency);
+    }
+}

--- a/tests/Commitments.Core.Tests/AggregateModel/CommitmentAggregate/CommitmentTests.cs
+++ b/tests/Commitments.Core.Tests/AggregateModel/CommitmentAggregate/CommitmentTests.cs
@@ -1,0 +1,102 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Core.AggregateModel.CommitmentAggregate;
+using FluentAssertions;
+using Xunit;
+
+namespace Commitments.Core.Tests.AggregateModel.CommitmentAggregate;
+
+public class CommitmentTests
+{
+    [Fact]
+    public void Commitment_ShouldInitializeWithEmptyCollections()
+    {
+        // Arrange & Act
+        var commitment = new Commitment();
+
+        // Assert
+        commitment.CommitmentFrequencies.Should().NotBeNull();
+        commitment.CommitmentFrequencies.Should().BeEmpty();
+        commitment.CommitmentPreConditions.Should().NotBeNull();
+        commitment.CommitmentPreConditions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Commitment_ShouldSetCommitmentId()
+    {
+        // Arrange
+        var commitment = new Commitment();
+        var id = Guid.NewGuid();
+
+        // Act
+        commitment.CommitmentId = id;
+
+        // Assert
+        commitment.CommitmentId.Should().Be(id);
+    }
+
+    [Fact]
+    public void Commitment_ShouldSetBehaviourId()
+    {
+        // Arrange
+        var commitment = new Commitment();
+        var behaviourId = Guid.NewGuid();
+
+        // Act
+        commitment.BehaviourId = behaviourId;
+
+        // Assert
+        commitment.BehaviourId.Should().Be(behaviourId);
+    }
+
+    [Fact]
+    public void Commitment_ShouldSetProfileId()
+    {
+        // Arrange
+        var commitment = new Commitment();
+        var profileId = Guid.NewGuid();
+
+        // Act
+        commitment.ProfileId = profileId;
+
+        // Assert
+        commitment.ProfileId.Should().Be(profileId);
+    }
+
+    [Fact]
+    public void Commitment_ShouldAddCommitmentFrequency()
+    {
+        // Arrange
+        var commitment = new Commitment();
+        var commitmentFrequency = new CommitmentFrequency
+        {
+            CommitmentFrequencyId = Guid.NewGuid(),
+            FrequencyId = Guid.NewGuid()
+        };
+
+        // Act
+        commitment.CommitmentFrequencies.Add(commitmentFrequency);
+
+        // Assert
+        commitment.CommitmentFrequencies.Should().HaveCount(1);
+        commitment.CommitmentFrequencies.Should().Contain(commitmentFrequency);
+    }
+
+    [Fact]
+    public void Commitment_ShouldInheritFromBaseEntity()
+    {
+        // Arrange & Act
+        var commitment = new Commitment();
+        var now = DateTime.UtcNow;
+
+        commitment.CreatedOn = now;
+        commitment.LastModifiedOn = now;
+        commitment.IsDeleted = true;
+
+        // Assert
+        commitment.CreatedOn.Should().Be(now);
+        commitment.LastModifiedOn.Should().Be(now);
+        commitment.IsDeleted.Should().BeTrue();
+    }
+}

--- a/tests/Commitments.Core.Tests/AggregateModel/CommitmentAggregate/Queries/GetCommitmentByIdTests.cs
+++ b/tests/Commitments.Core.Tests/AggregateModel/CommitmentAggregate/Queries/GetCommitmentByIdTests.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Core.AggregateModel.CommitmentAggregate;
+using Commitments.Core.AggregateModel.CommitmentAggregate.Queries;
+using FluentAssertions;
+using Xunit;
+
+namespace Commitments.Core.Tests.AggregateModel.CommitmentAggregate.Queries;
+
+public class GetCommitmentByIdTests
+{
+    [Fact]
+    public void GetCommitmentByIdValidator_ShouldPassWhenCommitmentIdIsValid()
+    {
+        // Arrange
+        var validator = new GetCommitmentByIdValidator();
+        var request = new GetCommitmentByIdRequest
+        {
+            CommitmentId = Guid.NewGuid()
+        };
+
+        // Act
+        var result = validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetCommitmentByIdValidator_ShouldFailWhenCommitmentIdIsDefault()
+    {
+        // Arrange
+        var validator = new GetCommitmentByIdValidator();
+        var request = new GetCommitmentByIdRequest
+        {
+            CommitmentId = default
+        };
+
+        // Act
+        var result = validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetCommitmentByIdRequest_ShouldSetCommitmentId()
+    {
+        // Arrange
+        var request = new GetCommitmentByIdRequest();
+        var commitmentId = Guid.NewGuid();
+
+        // Act
+        request.CommitmentId = commitmentId;
+
+        // Assert
+        request.CommitmentId.Should().Be(commitmentId);
+    }
+
+    [Fact]
+    public void GetCommitmentByIdResponse_ShouldSetCommitment()
+    {
+        // Arrange
+        var response = new GetCommitmentByIdResponse();
+        var commitment = new CommitmentDto { CommitmentId = Guid.NewGuid() };
+
+        // Act
+        response.Commitment = commitment;
+
+        // Assert
+        response.Commitment.Should().Be(commitment);
+    }
+}

--- a/tests/Commitments.Core.Tests/AggregateModel/CommitmentAggregate/Queries/GetCommitmentsTests.cs
+++ b/tests/Commitments.Core.Tests/AggregateModel/CommitmentAggregate/Queries/GetCommitmentsTests.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Core.AggregateModel.BehaviourAggregate;
+using Commitments.Core.AggregateModel.BehaviourTypeAggregate;
+using Commitments.Core.AggregateModel.CommitmentAggregate;
+using Commitments.Core.AggregateModel.CommitmentAggregate.Queries;
+using Commitments.Core.Tests.Helpers;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Commitments.Core.Tests.AggregateModel.CommitmentAggregate.Queries;
+
+public class GetCommitmentsTests
+{
+    [Fact]
+    public async Task GetCommitmentsQueryHandler_ShouldReturnEmptyListWhenNoCommitments()
+    {
+        // Arrange
+        var mockContext = MockDbContextFactory.Create();
+        var commitments = new List<Commitment>();
+        var mockDbSet = MockDbContextFactory.CreateMockDbSet(commitments);
+        mockContext.Setup(c => c.Commitments).Returns(mockDbSet.Object);
+
+        var handler = new GetCommitmentsQueryHandler(mockContext.Object);
+        var request = new GetCommitmentsRequest();
+
+        // Act
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Commitments.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetCommitmentsQueryHandler_ShouldReturnCommitments()
+    {
+        // Arrange
+        var mockContext = MockDbContextFactory.Create();
+
+        var behaviourType = new BehaviourType
+        {
+            BehaviourTypeId = Guid.NewGuid(),
+            Name = "Test Type"
+        };
+
+        var behaviour = new Behaviour
+        {
+            BehaviourId = Guid.NewGuid(),
+            Name = "Test Behaviour",
+            BehaviourType = behaviourType
+        };
+
+        var commitments = new List<Commitment>
+        {
+            new Commitment
+            {
+                CommitmentId = Guid.NewGuid(),
+                BehaviourId = behaviour.BehaviourId,
+                ProfileId = Guid.NewGuid(),
+                Behaviour = behaviour
+            }
+        };
+
+        var mockDbSet = MockDbContextFactory.CreateMockDbSet(commitments);
+        mockContext.Setup(c => c.Commitments).Returns(mockDbSet.Object);
+
+        var handler = new GetCommitmentsQueryHandler(mockContext.Object);
+        var request = new GetCommitmentsRequest();
+
+        // Act
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Commitments.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void GetCommitmentsRequest_ShouldBeCreatable()
+    {
+        // Arrange & Act
+        var request = new GetCommitmentsRequest();
+
+        // Assert
+        request.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void GetCommitmentsResponse_ShouldSetCommitments()
+    {
+        // Arrange
+        var response = new GetCommitmentsResponse();
+        var commitments = new List<CommitmentDto>
+        {
+            new CommitmentDto { CommitmentId = Guid.NewGuid() }
+        };
+
+        // Act
+        response.Commitments = commitments;
+
+        // Assert
+        response.Commitments.Should().HaveCount(1);
+    }
+}

--- a/tests/Commitments.Core.Tests/AggregateModel/DashboardAggregate/DashboardTests.cs
+++ b/tests/Commitments.Core.Tests/AggregateModel/DashboardAggregate/DashboardTests.cs
@@ -1,0 +1,154 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Core.AggregateModel.DashboardAggregate;
+using Commitments.Core.AggregateModel.DashboardCardAggregate;
+using Commitments.Core.AggregateModel.UserAggregate;
+using FluentAssertions;
+using Xunit;
+
+namespace Commitments.Core.Tests.AggregateModel.DashboardAggregate;
+
+public class DashboardTests
+{
+    [Fact]
+    public void Dashboard_ShouldInitializeWithName()
+    {
+        // Arrange
+        var name = "Test Dashboard";
+
+        // Act
+        var dashboard = new Dashboard(name);
+
+        // Assert
+        dashboard.Name.Should().Be(name);
+        dashboard.DashboardCards.Should().NotBeNull();
+        dashboard.DashboardCards.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Dashboard_ShouldInitializeWithNameAndUserId()
+    {
+        // Arrange
+        var name = "Test Dashboard";
+        var userId = Guid.NewGuid();
+
+        // Act
+        var dashboard = new Dashboard(name, userId);
+
+        // Assert
+        dashboard.Name.Should().Be(name);
+        dashboard.UserId.Should().Be(userId);
+    }
+
+    [Fact]
+    public void Dashboard_ShouldSetDashboardId()
+    {
+        // Arrange
+        var dashboard = new Dashboard("Test");
+        var id = Guid.NewGuid();
+
+        // Act
+        dashboard.DashboardId = id;
+
+        // Assert
+        dashboard.DashboardId.Should().Be(id);
+    }
+
+    [Fact]
+    public void Dashboard_ShouldSetName()
+    {
+        // Arrange
+        var dashboard = new Dashboard("Initial");
+        var newName = "Updated Dashboard";
+
+        // Act
+        dashboard.Name = newName;
+
+        // Assert
+        dashboard.Name.Should().Be(newName);
+    }
+
+    [Fact]
+    public void Dashboard_ShouldSetUserId()
+    {
+        // Arrange
+        var dashboard = new Dashboard("Test");
+        var userId = Guid.NewGuid();
+
+        // Act
+        dashboard.UserId = userId;
+
+        // Assert
+        dashboard.UserId.Should().Be(userId);
+    }
+
+    [Fact]
+    public void Dashboard_ShouldSetProfileId()
+    {
+        // Arrange
+        var dashboard = new Dashboard("Test");
+        var profileId = Guid.NewGuid();
+
+        // Act
+        dashboard.ProfileId = profileId;
+
+        // Assert
+        dashboard.ProfileId.Should().Be(profileId);
+    }
+
+    [Fact]
+    public void Dashboard_ShouldAllowNullUserId()
+    {
+        // Arrange
+        var dashboard = new Dashboard("Test", Guid.NewGuid());
+
+        // Act
+        dashboard.UserId = null;
+
+        // Assert
+        dashboard.UserId.Should().BeNull();
+    }
+
+    [Fact]
+    public void Dashboard_ShouldAllowNullProfileId()
+    {
+        // Arrange
+        var dashboard = new Dashboard("Test");
+
+        // Act
+        dashboard.ProfileId = null;
+
+        // Assert
+        dashboard.ProfileId.Should().BeNull();
+    }
+
+    [Fact]
+    public void Dashboard_ShouldSetUser()
+    {
+        // Arrange
+        var dashboard = new Dashboard("Test");
+        var user = new User { UserId = Guid.NewGuid(), Username = "testuser" };
+
+        // Act
+        dashboard.User = user;
+
+        // Assert
+        dashboard.User.Should().Be(user);
+    }
+
+    [Fact]
+    public void Dashboard_ShouldAddDashboardCard()
+    {
+        // Arrange
+        var dashboard = new Dashboard("Test");
+        var dashboardCard = new DashboardCard { DashboardCardId = Guid.NewGuid() };
+
+        // Act
+        dashboard.DashboardCards.Add(dashboardCard);
+
+        // Assert
+        dashboard.DashboardCards.Should().HaveCount(1);
+        dashboard.DashboardCards.Should().Contain(dashboardCard);
+    }
+}

--- a/tests/Commitments.Core.Tests/AggregateModel/DashboardCardAggregate/DashboardCardTests.cs
+++ b/tests/Commitments.Core.Tests/AggregateModel/DashboardCardAggregate/DashboardCardTests.cs
@@ -1,0 +1,128 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Core.AggregateModel.CardAggregate;
+using Commitments.Core.AggregateModel.CardLayoutAggregate;
+using Commitments.Core.AggregateModel.DashboardAggregate;
+using Commitments.Core.AggregateModel.DashboardCardAggregate;
+using FluentAssertions;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Commitments.Core.Tests.AggregateModel.DashboardCardAggregate;
+
+public class DashboardCardTests
+{
+    [Fact]
+    public void DashboardCard_ShouldSetDashboardCardId()
+    {
+        // Arrange
+        var dashboardCard = new DashboardCard();
+        var id = Guid.NewGuid();
+
+        // Act
+        dashboardCard.DashboardCardId = id;
+
+        // Assert
+        dashboardCard.DashboardCardId.Should().Be(id);
+    }
+
+    [Fact]
+    public void DashboardCard_ShouldSetDashboardId()
+    {
+        // Arrange
+        var dashboardCard = new DashboardCard();
+        var dashboardId = Guid.NewGuid();
+
+        // Act
+        dashboardCard.DashboardId = dashboardId;
+
+        // Assert
+        dashboardCard.DashboardId.Should().Be(dashboardId);
+    }
+
+    [Fact]
+    public void DashboardCard_ShouldSetCardId()
+    {
+        // Arrange
+        var dashboardCard = new DashboardCard();
+        var cardId = Guid.NewGuid();
+
+        // Act
+        dashboardCard.CardId = cardId;
+
+        // Assert
+        dashboardCard.CardId.Should().Be(cardId);
+    }
+
+    [Fact]
+    public void DashboardCard_ShouldSetCardLayoutId()
+    {
+        // Arrange
+        var dashboardCard = new DashboardCard();
+        var cardLayoutId = Guid.NewGuid();
+
+        // Act
+        dashboardCard.CardLayoutId = cardLayoutId;
+
+        // Assert
+        dashboardCard.CardLayoutId.Should().Be(cardLayoutId);
+    }
+
+    [Fact]
+    public void DashboardCard_ShouldSetDashboard()
+    {
+        // Arrange
+        var dashboardCard = new DashboardCard();
+        var dashboard = new Dashboard("Test Dashboard");
+
+        // Act
+        dashboardCard.Dashboard = dashboard;
+
+        // Assert
+        dashboardCard.Dashboard.Should().Be(dashboard);
+    }
+
+    [Fact]
+    public void DashboardCard_ShouldSetCard()
+    {
+        // Arrange
+        var dashboardCard = new DashboardCard();
+        var card = new Card { CardId = Guid.NewGuid(), Name = "Test Card" };
+
+        // Act
+        dashboardCard.Card = card;
+
+        // Assert
+        dashboardCard.Card.Should().Be(card);
+    }
+
+    [Fact]
+    public void DashboardCard_ShouldSetCardLayout()
+    {
+        // Arrange
+        var dashboardCard = new DashboardCard();
+        var cardLayout = new CardLayout { CardLayoutId = Guid.NewGuid() };
+
+        // Act
+        dashboardCard.CardLayout = cardLayout;
+
+        // Assert
+        dashboardCard.CardLayout.Should().Be(cardLayout);
+    }
+
+    [Fact]
+    public void DashboardCard_ShouldSetOptions()
+    {
+        // Arrange
+        var dashboardCard = new DashboardCard();
+        var options = JObject.Parse("{\"key\": \"value\"}");
+
+        // Act
+        dashboardCard.Options = options;
+
+        // Assert
+        dashboardCard.Options.Should().NotBeNull();
+        dashboardCard.Options["key"]!.Value<string>().Should().Be("value");
+    }
+}

--- a/tests/Commitments.Core.Tests/AggregateModel/DigitalAssetAggregate/DigitalAssetTests.cs
+++ b/tests/Commitments.Core.Tests/AggregateModel/DigitalAssetAggregate/DigitalAssetTests.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Core.AggregateModel.DigitalAssetAggregate;
+using FluentAssertions;
+using Xunit;
+
+namespace Commitments.Core.Tests.AggregateModel.DigitalAssetAggregate;
+
+public class DigitalAssetTests
+{
+    [Fact]
+    public void DigitalAsset_ShouldSetDigitalAssetId()
+    {
+        // Arrange
+        var digitalAsset = new DigitalAsset();
+        var id = Guid.NewGuid();
+
+        // Act
+        digitalAsset.DigitalAssetId = id;
+
+        // Assert
+        digitalAsset.DigitalAssetId.Should().Be(id);
+    }
+
+    [Fact]
+    public void DigitalAsset_ShouldSetBytes()
+    {
+        // Arrange
+        var digitalAsset = new DigitalAsset();
+        var bytes = new byte[] { 1, 2, 3, 4, 5 };
+
+        // Act
+        digitalAsset.Bytes = bytes;
+
+        // Assert
+        digitalAsset.Bytes.Should().BeEquivalentTo(bytes);
+    }
+
+    [Fact]
+    public void DigitalAsset_ShouldSetContentType()
+    {
+        // Arrange
+        var digitalAsset = new DigitalAsset();
+        var contentType = "image/png";
+
+        // Act
+        digitalAsset.ContentType = contentType;
+
+        // Assert
+        digitalAsset.ContentType.Should().Be(contentType);
+    }
+
+    [Fact]
+    public void DigitalAsset_ShouldSetName()
+    {
+        // Arrange
+        var digitalAsset = new DigitalAsset();
+        var name = "test-image.png";
+
+        // Act
+        digitalAsset.Name = name;
+
+        // Assert
+        digitalAsset.Name.Should().Be(name);
+    }
+
+    [Fact]
+    public void DigitalAsset_ShouldAllowNullBytes()
+    {
+        // Arrange
+        var digitalAsset = new DigitalAsset();
+
+        // Act
+        digitalAsset.Bytes = null;
+
+        // Assert
+        digitalAsset.Bytes.Should().BeNull();
+    }
+
+    [Fact]
+    public void DigitalAsset_ShouldAllowNullContentType()
+    {
+        // Arrange
+        var digitalAsset = new DigitalAsset();
+
+        // Act
+        digitalAsset.ContentType = null;
+
+        // Assert
+        digitalAsset.ContentType.Should().BeNull();
+    }
+
+    [Fact]
+    public void DigitalAsset_ShouldAllowNullName()
+    {
+        // Arrange
+        var digitalAsset = new DigitalAsset();
+
+        // Act
+        digitalAsset.Name = null;
+
+        // Assert
+        digitalAsset.Name.Should().BeNull();
+    }
+
+    [Fact]
+    public void DigitalAsset_ShouldHandleLargeByteArray()
+    {
+        // Arrange
+        var digitalAsset = new DigitalAsset();
+        var bytes = new byte[1000000]; // 1MB
+
+        // Act
+        digitalAsset.Bytes = bytes;
+
+        // Assert
+        digitalAsset.Bytes.Should().HaveCount(1000000);
+    }
+}

--- a/tests/Commitments.Core.Tests/AggregateModel/FrequencyAggregate/FrequencyTests.cs
+++ b/tests/Commitments.Core.Tests/AggregateModel/FrequencyAggregate/FrequencyTests.cs
@@ -1,0 +1,132 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Core.AggregateModel.CommitmentAggregate;
+using Commitments.Core.AggregateModel.FrequencyAggregate;
+using Commitments.Core.AggregateModel.FrequencyTypeAggregate;
+using FluentAssertions;
+using Xunit;
+
+namespace Commitments.Core.Tests.AggregateModel.FrequencyAggregate;
+
+public class FrequencyTests
+{
+    [Fact]
+    public void Frequency_ShouldInitializeWithEmptyCommitmentFrequenciesCollection()
+    {
+        // Arrange & Act
+        var frequency = new Frequency();
+
+        // Assert
+        frequency.CommitmentFrequencies.Should().NotBeNull();
+        frequency.CommitmentFrequencies.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Frequency_ShouldSetFrequencyId()
+    {
+        // Arrange
+        var frequency = new Frequency();
+        var id = Guid.NewGuid();
+
+        // Act
+        frequency.FrequencyId = id;
+
+        // Assert
+        frequency.FrequencyId.Should().Be(id);
+    }
+
+    [Fact]
+    public void Frequency_ShouldSetFrequencyTypeId()
+    {
+        // Arrange
+        var frequency = new Frequency();
+        var frequencyTypeId = Guid.NewGuid();
+
+        // Act
+        frequency.FrequencyTypeId = frequencyTypeId;
+
+        // Assert
+        frequency.FrequencyTypeId.Should().Be(frequencyTypeId);
+    }
+
+    [Fact]
+    public void Frequency_ShouldSetIsDesirable()
+    {
+        // Arrange
+        var frequency = new Frequency();
+
+        // Act
+        frequency.IsDesirable = true;
+
+        // Assert
+        frequency.IsDesirable.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Frequency_ShouldSetFrequencyType()
+    {
+        // Arrange
+        var frequency = new Frequency();
+        var frequencyType = new FrequencyType
+        {
+            FrequencyTypeId = Guid.NewGuid(),
+            Name = "Daily"
+        };
+
+        // Act
+        frequency.FrequencyType = frequencyType;
+
+        // Assert
+        frequency.FrequencyType.Should().Be(frequencyType);
+    }
+
+    [Fact]
+    public void Frequency_ShouldAddCommitmentFrequency()
+    {
+        // Arrange
+        var frequency = new Frequency();
+        var commitmentFrequency = new CommitmentFrequency
+        {
+            CommitmentFrequencyId = Guid.NewGuid()
+        };
+
+        // Act
+        frequency.CommitmentFrequencies.Add(commitmentFrequency);
+
+        // Assert
+        frequency.CommitmentFrequencies.Should().HaveCount(1);
+        frequency.CommitmentFrequencies.Should().Contain(commitmentFrequency);
+    }
+
+    [Fact]
+    public void Frequency_ShouldInheritFromBaseFrequency()
+    {
+        // Arrange
+        var frequency = new Frequency();
+        var baseFrequencyValue = Guid.NewGuid();
+
+        // Act
+        frequency.Frequency = baseFrequencyValue;
+
+        // Assert
+        frequency.Frequency.Should().Be(baseFrequencyValue);
+    }
+
+    [Fact]
+    public void Frequency_ShouldInheritFromBaseEntity()
+    {
+        // Arrange & Act
+        var frequency = new Frequency();
+        var now = DateTime.UtcNow;
+
+        frequency.CreatedOn = now;
+        frequency.LastModifiedOn = now;
+        frequency.IsDeleted = true;
+
+        // Assert
+        frequency.CreatedOn.Should().Be(now);
+        frequency.LastModifiedOn.Should().Be(now);
+        frequency.IsDeleted.Should().BeTrue();
+    }
+}

--- a/tests/Commitments.Core.Tests/AggregateModel/FrequencyTypeAggregate/FrequencyTypeTests.cs
+++ b/tests/Commitments.Core.Tests/AggregateModel/FrequencyTypeAggregate/FrequencyTypeTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Core.AggregateModel.FrequencyTypeAggregate;
+using FluentAssertions;
+using Xunit;
+
+namespace Commitments.Core.Tests.AggregateModel.FrequencyTypeAggregate;
+
+public class FrequencyTypeTests
+{
+    [Fact]
+    public void FrequencyType_ShouldSetFrequencyTypeId()
+    {
+        // Arrange
+        var frequencyType = new FrequencyType();
+        var id = Guid.NewGuid();
+
+        // Act
+        frequencyType.FrequencyTypeId = id;
+
+        // Assert
+        frequencyType.FrequencyTypeId.Should().Be(id);
+    }
+
+    [Fact]
+    public void FrequencyType_ShouldSetName()
+    {
+        // Arrange
+        var frequencyType = new FrequencyType();
+        var name = "Daily";
+
+        // Act
+        frequencyType.Name = name;
+
+        // Assert
+        frequencyType.Name.Should().Be(name);
+    }
+
+    [Fact]
+    public void FrequencyType_ShouldInheritFromBaseEntity()
+    {
+        // Arrange & Act
+        var frequencyType = new FrequencyType();
+        var now = DateTime.UtcNow;
+
+        frequencyType.CreatedOn = now;
+        frequencyType.LastModifiedOn = now;
+        frequencyType.IsDeleted = true;
+
+        // Assert
+        frequencyType.CreatedOn.Should().Be(now);
+        frequencyType.LastModifiedOn.Should().Be(now);
+        frequencyType.IsDeleted.Should().BeTrue();
+    }
+}

--- a/tests/Commitments.Core.Tests/AggregateModel/ProfileTests.cs
+++ b/tests/Commitments.Core.Tests/AggregateModel/ProfileTests.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Core.AggregateModel;
+using FluentAssertions;
+using Xunit;
+
+namespace Commitments.Core.Tests.AggregateModel;
+
+public class ProfileTests
+{
+    [Fact]
+    public void Profile_ShouldSetProfileId()
+    {
+        // Arrange
+        var profile = new Profile();
+        var id = Guid.NewGuid();
+
+        // Act
+        profile.ProfileId = id;
+
+        // Assert
+        profile.ProfileId.Should().Be(id);
+    }
+
+    [Fact]
+    public void Profile_ShouldInheritFromBaseEntity()
+    {
+        // Arrange & Act
+        var profile = new Profile();
+        var now = DateTime.UtcNow;
+
+        profile.CreatedOn = now;
+        profile.LastModifiedOn = now;
+        profile.IsDeleted = true;
+
+        // Assert
+        profile.CreatedOn.Should().Be(now);
+        profile.LastModifiedOn.Should().Be(now);
+        profile.IsDeleted.Should().BeTrue();
+    }
+}

--- a/tests/Commitments.Core.Tests/AggregateModel/UserAggregate/UserTests.cs
+++ b/tests/Commitments.Core.Tests/AggregateModel/UserAggregate/UserTests.cs
@@ -1,0 +1,164 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Core.AggregateModel.DashboardAggregate;
+using Commitments.Core.AggregateModel.UserAggregate;
+using FluentAssertions;
+using Xunit;
+
+namespace Commitments.Core.Tests.AggregateModel.UserAggregate;
+
+public class UserTests
+{
+    [Fact]
+    public void User_ShouldInitializeWithEmptyDashboardsCollection()
+    {
+        // Arrange & Act
+        var user = new User();
+
+        // Assert
+        user.Dashboards.Should().NotBeNull();
+        user.Dashboards.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void User_ShouldSetUserId()
+    {
+        // Arrange
+        var user = new User();
+        var id = Guid.NewGuid();
+
+        // Act
+        user.UserId = id;
+
+        // Assert
+        user.UserId.Should().Be(id);
+    }
+
+    [Fact]
+    public void User_ShouldSetUsername()
+    {
+        // Arrange
+        var user = new User();
+        var username = "testuser";
+
+        // Act
+        user.Username = username;
+
+        // Assert
+        user.Username.Should().Be(username);
+    }
+
+    [Fact]
+    public void User_ShouldSetFirstName()
+    {
+        // Arrange
+        var user = new User();
+        var firstName = "John";
+
+        // Act
+        user.FirstName = firstName;
+
+        // Assert
+        user.FirstName.Should().Be(firstName);
+    }
+
+    [Fact]
+    public void User_ShouldSetLastName()
+    {
+        // Arrange
+        var user = new User();
+        var lastName = "Doe";
+
+        // Act
+        user.LastName = lastName;
+
+        // Assert
+        user.LastName.Should().Be(lastName);
+    }
+
+    [Fact]
+    public void User_ShouldSetEmail()
+    {
+        // Arrange
+        var user = new User();
+        var email = "john.doe@example.com";
+
+        // Act
+        user.Email = email;
+
+        // Assert
+        user.Email.Should().Be(email);
+    }
+
+    [Fact]
+    public void User_ShouldAllowNullFirstName()
+    {
+        // Arrange
+        var user = new User();
+
+        // Act
+        user.FirstName = null;
+
+        // Assert
+        user.FirstName.Should().BeNull();
+    }
+
+    [Fact]
+    public void User_ShouldAllowNullLastName()
+    {
+        // Arrange
+        var user = new User();
+
+        // Act
+        user.LastName = null;
+
+        // Assert
+        user.LastName.Should().BeNull();
+    }
+
+    [Fact]
+    public void User_ShouldAllowNullEmail()
+    {
+        // Arrange
+        var user = new User();
+
+        // Act
+        user.Email = null;
+
+        // Assert
+        user.Email.Should().BeNull();
+    }
+
+    [Fact]
+    public void User_ShouldAddDashboard()
+    {
+        // Arrange
+        var user = new User();
+        var dashboard = new Dashboard("Test Dashboard");
+
+        // Act
+        user.Dashboards.Add(dashboard);
+
+        // Assert
+        user.Dashboards.Should().HaveCount(1);
+        user.Dashboards.Should().Contain(dashboard);
+    }
+
+    [Fact]
+    public void User_ShouldInheritFromBaseEntity()
+    {
+        // Arrange & Act
+        var user = new User();
+        var now = DateTime.UtcNow;
+
+        user.CreatedOn = now;
+        user.LastModifiedOn = now;
+        user.IsDeleted = true;
+
+        // Assert
+        user.CreatedOn.Should().Be(now);
+        user.LastModifiedOn.Should().Be(now);
+        user.IsDeleted.Should().BeTrue();
+    }
+}

--- a/tests/Commitments.Core.Tests/Commitments.Core.Tests.csproj
+++ b/tests/Commitments.Core.Tests/Commitments.Core.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Commitments.Core\Commitments.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Commitments.Core.Tests/Extensions/HttpContextAccessorExtensionsTests.cs
+++ b/tests/Commitments.Core.Tests/Extensions/HttpContextAccessorExtensionsTests.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Core.Extensions;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using System.Security.Claims;
+using Xunit;
+
+namespace Commitments.Core.Tests.Extensions;
+
+public class HttpContextAccessorExtensionsTests
+{
+    [Fact]
+    public void GetProfileId_ShouldReturnProfileIdFromClaims()
+    {
+        // Arrange
+        var profileId = Guid.NewGuid();
+        var claims = new List<Claim>
+        {
+            new Claim("ProfileId", profileId.ToString())
+        };
+        var identity = new ClaimsIdentity(claims, "test");
+        var principal = new ClaimsPrincipal(identity);
+
+        var mockHttpContext = new Mock<HttpContext>();
+        mockHttpContext.Setup(c => c.User).Returns(principal);
+
+        var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+        mockHttpContextAccessor.Setup(a => a.HttpContext).Returns(mockHttpContext.Object);
+
+        // Act
+        var result = mockHttpContextAccessor.Object.GetProfileId();
+
+        // Assert
+        result.Should().Be(profileId);
+    }
+
+    [Fact]
+    public void GetProfileId_ShouldReturnEmptyGuidWhenNoProfileIdClaim()
+    {
+        // Arrange
+        var claims = new List<Claim>();
+        var identity = new ClaimsIdentity(claims, "test");
+        var principal = new ClaimsPrincipal(identity);
+
+        var mockHttpContext = new Mock<HttpContext>();
+        mockHttpContext.Setup(c => c.User).Returns(principal);
+
+        var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+        mockHttpContextAccessor.Setup(a => a.HttpContext).Returns(mockHttpContext.Object);
+
+        // Act
+        var result = mockHttpContextAccessor.Object.GetProfileId();
+
+        // Assert
+        result.Should().Be(Guid.Empty);
+    }
+
+    [Fact]
+    public void GetProfileId_ShouldReturnEmptyGuidWhenHttpContextIsNull()
+    {
+        // Arrange
+        var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+        mockHttpContextAccessor.Setup(a => a.HttpContext).Returns((HttpContext?)null);
+
+        // Act
+        var result = mockHttpContextAccessor.Object.GetProfileId();
+
+        // Assert
+        result.Should().Be(Guid.Empty);
+    }
+
+    [Fact]
+    public void GetProfileId_ShouldReturnEmptyGuidWhenClaimValueIsInvalid()
+    {
+        // Arrange
+        var claims = new List<Claim>
+        {
+            new Claim("ProfileId", "invalid-guid")
+        };
+        var identity = new ClaimsIdentity(claims, "test");
+        var principal = new ClaimsPrincipal(identity);
+
+        var mockHttpContext = new Mock<HttpContext>();
+        mockHttpContext.Setup(c => c.User).Returns(principal);
+
+        var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+        mockHttpContextAccessor.Setup(a => a.HttpContext).Returns(mockHttpContext.Object);
+
+        // Act
+        var result = mockHttpContextAccessor.Object.GetProfileId();
+
+        // Assert
+        result.Should().Be(Guid.Empty);
+    }
+}

--- a/tests/Commitments.Core.Tests/Helpers/MockDbContextFactory.cs
+++ b/tests/Commitments.Core.Tests/Helpers/MockDbContextFactory.cs
@@ -1,0 +1,157 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Core;
+using Commitments.Core.AggregateModel;
+using Commitments.Core.AggregateModel.ActivityAggregate;
+using Commitments.Core.AggregateModel.BehaviourAggregate;
+using Commitments.Core.AggregateModel.BehaviourTypeAggregate;
+using Commitments.Core.AggregateModel.CardAggregate;
+using Commitments.Core.AggregateModel.CardLayoutAggregate;
+using Commitments.Core.AggregateModel.CommitmentAggregate;
+using Commitments.Core.AggregateModel.DashboardAggregate;
+using Commitments.Core.AggregateModel.DashboardCardAggregate;
+using Commitments.Core.AggregateModel.DigitalAssetAggregate;
+using Commitments.Core.AggregateModel.FrequencyAggregate;
+using Commitments.Core.AggregateModel.FrequencyTypeAggregate;
+using Commitments.Core.AggregateModel.UserAggregate;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+
+namespace Commitments.Core.Tests.Helpers;
+
+public static class MockDbContextFactory
+{
+    public static Mock<ICommitmentsDbContext> Create()
+    {
+        var mockContext = new Mock<ICommitmentsDbContext>();
+
+        // Setup empty DbSets
+        mockContext.Setup(c => c.Activities).Returns(CreateMockDbSet<Activity>().Object);
+        mockContext.Setup(c => c.Behaviours).Returns(CreateMockDbSet<Behaviour>().Object);
+        mockContext.Setup(c => c.BehaviourTypes).Returns(CreateMockDbSet<BehaviourType>().Object);
+        mockContext.Setup(c => c.Commitments).Returns(CreateMockDbSet<Commitment>().Object);
+        mockContext.Setup(c => c.CommitmentFrequencies).Returns(CreateMockDbSet<CommitmentFrequency>().Object);
+        mockContext.Setup(c => c.Frequencies).Returns(CreateMockDbSet<Frequency>().Object);
+        mockContext.Setup(c => c.FrequencyTypes).Returns(CreateMockDbSet<FrequencyType>().Object);
+        mockContext.Setup(c => c.Cards).Returns(CreateMockDbSet<Card>().Object);
+        mockContext.Setup(c => c.CardLayouts).Returns(CreateMockDbSet<CardLayout>().Object);
+        mockContext.Setup(c => c.Dashboards).Returns(CreateMockDbSet<Dashboard>().Object);
+        mockContext.Setup(c => c.DashboardCards).Returns(CreateMockDbSet<DashboardCard>().Object);
+        mockContext.Setup(c => c.Profiles).Returns(CreateMockDbSet<Profile>().Object);
+        mockContext.Setup(c => c.ProfileCommitments).Returns(CreateMockDbSet<Commitment>().Object);
+        mockContext.Setup(c => c.Users).Returns(CreateMockDbSet<User>().Object);
+        mockContext.Setup(c => c.DigitalAssets).Returns(CreateMockDbSet<DigitalAsset>().Object);
+        mockContext.Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+        return mockContext;
+    }
+
+    public static Mock<DbSet<T>> CreateMockDbSet<T>() where T : class
+    {
+        return CreateMockDbSet(new List<T>());
+    }
+
+    public static Mock<DbSet<T>> CreateMockDbSet<T>(List<T> data) where T : class
+    {
+        var queryable = data.AsQueryable();
+        var mockSet = new Mock<DbSet<T>>();
+
+        mockSet.As<IQueryable<T>>().Setup(m => m.Provider).Returns(new TestAsyncQueryProvider<T>(queryable.Provider));
+        mockSet.As<IQueryable<T>>().Setup(m => m.Expression).Returns(queryable.Expression);
+        mockSet.As<IQueryable<T>>().Setup(m => m.ElementType).Returns(queryable.ElementType);
+        mockSet.As<IQueryable<T>>().Setup(m => m.GetEnumerator()).Returns(() => queryable.GetEnumerator());
+        mockSet.As<IAsyncEnumerable<T>>().Setup(m => m.GetAsyncEnumerator(It.IsAny<CancellationToken>()))
+            .Returns(new TestAsyncEnumerator<T>(queryable.GetEnumerator()));
+        mockSet.Setup(d => d.Add(It.IsAny<T>())).Callback<T>(data.Add);
+
+        return mockSet;
+    }
+}
+
+internal class TestAsyncQueryProvider<TEntity> : IAsyncQueryProvider
+{
+    private readonly IQueryProvider _inner;
+
+    internal TestAsyncQueryProvider(IQueryProvider inner)
+    {
+        _inner = inner;
+    }
+
+    public IQueryable CreateQuery(System.Linq.Expressions.Expression expression)
+    {
+        return new TestAsyncEnumerable<TEntity>(expression);
+    }
+
+    public IQueryable<TElement> CreateQuery<TElement>(System.Linq.Expressions.Expression expression)
+    {
+        return new TestAsyncEnumerable<TElement>(expression);
+    }
+
+    public object? Execute(System.Linq.Expressions.Expression expression)
+    {
+        return _inner.Execute(expression);
+    }
+
+    public TResult Execute<TResult>(System.Linq.Expressions.Expression expression)
+    {
+        return _inner.Execute<TResult>(expression);
+    }
+
+    public TResult ExecuteAsync<TResult>(System.Linq.Expressions.Expression expression, CancellationToken cancellationToken = default)
+    {
+        var expectedResultType = typeof(TResult).GetGenericArguments()[0];
+        var executionResult = typeof(IQueryProvider)
+            .GetMethod(
+                name: nameof(IQueryProvider.Execute),
+                genericParameterCount: 1,
+                types: new[] { typeof(System.Linq.Expressions.Expression) })!
+            .MakeGenericMethod(expectedResultType)
+            .Invoke(this, new[] { expression });
+
+        return (TResult)typeof(Task).GetMethod(nameof(Task.FromResult))!
+            .MakeGenericMethod(expectedResultType)
+            .Invoke(null, new[] { executionResult })!;
+    }
+}
+
+internal class TestAsyncEnumerable<T> : EnumerableQuery<T>, IAsyncEnumerable<T>, IQueryable<T>
+{
+    public TestAsyncEnumerable(IEnumerable<T> enumerable)
+        : base(enumerable)
+    { }
+
+    public TestAsyncEnumerable(System.Linq.Expressions.Expression expression)
+        : base(expression)
+    { }
+
+    public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+    {
+        return new TestAsyncEnumerator<T>(this.AsEnumerable().GetEnumerator());
+    }
+
+    IQueryProvider IQueryable.Provider => new TestAsyncQueryProvider<T>(this);
+}
+
+internal class TestAsyncEnumerator<T> : IAsyncEnumerator<T>
+{
+    private readonly IEnumerator<T> _inner;
+
+    public TestAsyncEnumerator(IEnumerator<T> inner)
+    {
+        _inner = inner;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _inner.Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask<bool> MoveNextAsync()
+    {
+        return ValueTask.FromResult(_inner.MoveNext());
+    }
+
+    public T Current => _inner.Current;
+}

--- a/tests/Commitments.Core.Tests/Services/Kernel/StringExtensionsTests.cs
+++ b/tests/Commitments.Core.Tests/Services/Kernel/StringExtensionsTests.cs
@@ -1,0 +1,141 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Core.Services.Kernel;
+using FluentAssertions;
+using Xunit;
+
+namespace Commitments.Core.Tests.Services.Kernel;
+
+public class StringExtensionsTests
+{
+    [Fact]
+    public void ToCamelCase_ShouldConvertPascalCaseToCamelCase()
+    {
+        // Arrange
+        var input = "HelloWorld";
+
+        // Act
+        var result = input.ToCamelCase();
+
+        // Assert
+        result.Should().Be("helloWorld");
+    }
+
+    [Fact]
+    public void ToCamelCase_ShouldReturnSameStringWhenAlreadyCamelCase()
+    {
+        // Arrange
+        var input = "helloWorld";
+
+        // Act
+        var result = input.ToCamelCase();
+
+        // Assert
+        result.Should().Be("helloWorld");
+    }
+
+    [Fact]
+    public void ToCamelCase_ShouldHandleSingleUppercaseCharacter()
+    {
+        // Arrange
+        var input = "A";
+
+        // Act
+        var result = input.ToCamelCase();
+
+        // Assert
+        result.Should().Be("a");
+    }
+
+    [Fact]
+    public void ToCamelCase_ShouldHandleSingleLowercaseCharacter()
+    {
+        // Arrange
+        var input = "a";
+
+        // Act
+        var result = input.ToCamelCase();
+
+        // Assert
+        result.Should().Be("a");
+    }
+
+    [Fact]
+    public void ToCamelCase_ShouldReturnEmptyStringForEmptyInput()
+    {
+        // Arrange
+        var input = "";
+
+        // Act
+        var result = input.ToCamelCase();
+
+        // Assert
+        result.Should().Be("");
+    }
+
+    [Fact]
+    public void ToCamelCase_ShouldReturnNullForNullInput()
+    {
+        // Arrange
+        string? input = null;
+
+        // Act
+        var result = input.ToCamelCase();
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToCamelCase_ShouldHandleAllUppercase()
+    {
+        // Arrange
+        var input = "HELLO";
+
+        // Act
+        var result = input.ToCamelCase();
+
+        // Assert
+        result.Should().Be("hELLO");
+    }
+
+    [Fact]
+    public void ToCamelCase_ShouldHandleAllLowercase()
+    {
+        // Arrange
+        var input = "hello";
+
+        // Act
+        var result = input.ToCamelCase();
+
+        // Assert
+        result.Should().Be("hello");
+    }
+
+    [Fact]
+    public void ToCamelCase_ShouldHandleStringWithNumbers()
+    {
+        // Arrange
+        var input = "Hello123World";
+
+        // Act
+        var result = input.ToCamelCase();
+
+        // Assert
+        result.Should().Be("hello123World");
+    }
+
+    [Fact]
+    public void ToCamelCase_ShouldHandleStringWithSpecialCharacters()
+    {
+        // Arrange
+        var input = "Hello_World";
+
+        // Act
+        var result = input.ToCamelCase();
+
+        // Assert
+        result.Should().Be("hello_World");
+    }
+}

--- a/tests/Commitments.Core.Tests/Services/Security/PasswordHasherTests.cs
+++ b/tests/Commitments.Core.Tests/Services/Security/PasswordHasherTests.cs
@@ -1,0 +1,130 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Core.Services.Security;
+using FluentAssertions;
+using Xunit;
+
+namespace Commitments.Core.Tests.Services.Security;
+
+public class PasswordHasherTests
+{
+    private readonly PasswordHasher _passwordHasher;
+
+    public PasswordHasherTests()
+    {
+        _passwordHasher = new PasswordHasher();
+    }
+
+    [Fact]
+    public void HashPassword_ShouldReturnNonEmptyString()
+    {
+        // Arrange
+        var salt = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+        var password = "testPassword123";
+
+        // Act
+        var result = _passwordHasher.HashPassword(salt, password);
+
+        // Assert
+        result.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void HashPassword_ShouldReturnBase64String()
+    {
+        // Arrange
+        var salt = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+        var password = "testPassword123";
+
+        // Act
+        var result = _passwordHasher.HashPassword(salt, password);
+        var isValidBase64 = !string.IsNullOrWhiteSpace(result);
+        try
+        {
+            Convert.FromBase64String(result);
+        }
+        catch
+        {
+            isValidBase64 = false;
+        }
+
+        // Assert
+        isValidBase64.Should().BeTrue();
+    }
+
+    [Fact]
+    public void HashPassword_ShouldReturnSameHashForSameInput()
+    {
+        // Arrange
+        var salt = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+        var password = "testPassword123";
+
+        // Act
+        var result1 = _passwordHasher.HashPassword(salt, password);
+        var result2 = _passwordHasher.HashPassword(salt, password);
+
+        // Assert
+        result1.Should().Be(result2);
+    }
+
+    [Fact]
+    public void HashPassword_ShouldReturnDifferentHashForDifferentSalt()
+    {
+        // Arrange
+        var salt1 = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+        var salt2 = new byte[] { 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1 };
+        var password = "testPassword123";
+
+        // Act
+        var result1 = _passwordHasher.HashPassword(salt1, password);
+        var result2 = _passwordHasher.HashPassword(salt2, password);
+
+        // Assert
+        result1.Should().NotBe(result2);
+    }
+
+    [Fact]
+    public void HashPassword_ShouldReturnDifferentHashForDifferentPassword()
+    {
+        // Arrange
+        var salt = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+        var password1 = "testPassword123";
+        var password2 = "testPassword456";
+
+        // Act
+        var result1 = _passwordHasher.HashPassword(salt, password1);
+        var result2 = _passwordHasher.HashPassword(salt, password2);
+
+        // Assert
+        result1.Should().NotBe(result2);
+    }
+
+    [Fact]
+    public void HashPassword_ShouldHandleEmptyPassword()
+    {
+        // Arrange
+        var salt = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+        var password = "";
+
+        // Act
+        var result = _passwordHasher.HashPassword(salt, password);
+
+        // Assert
+        result.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void HashPassword_ShouldHandleLongPassword()
+    {
+        // Arrange
+        var salt = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+        var password = new string('a', 1000);
+
+        // Act
+        var result = _passwordHasher.HashPassword(salt, password);
+
+        // Assert
+        result.Should().NotBeNullOrEmpty();
+    }
+}

--- a/tests/Commitments.Core.Tests/Services/Security/TokenBuilderTests.cs
+++ b/tests/Commitments.Core.Tests/Services/Security/TokenBuilderTests.cs
@@ -1,0 +1,185 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Core.Services.Security;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using Xunit;
+
+namespace Commitments.Core.Tests.Services.Security;
+
+public class TokenBuilderTests
+{
+    private readonly Mock<IConfiguration> _mockConfiguration;
+
+    public TokenBuilderTests()
+    {
+        _mockConfiguration = new Mock<IConfiguration>();
+        _mockConfiguration.Setup(c => c["Authentication:JwtKey"]).Returns("VerySecretKeyThatIsAtLeast32CharactersLong");
+        _mockConfiguration.Setup(c => c["Authentication:JwtIssuer"]).Returns("TestIssuer");
+        _mockConfiguration.Setup(c => c["Authentication:JwtAudience"]).Returns("TestAudience");
+        _mockConfiguration.Setup(c => c["Authentication:ExpirationMinutes"]).Returns("60");
+    }
+
+    [Fact]
+    public void Build_ShouldReturnValidJwtToken()
+    {
+        // Arrange
+        var tokenBuilder = new TokenBuilder(_mockConfiguration.Object);
+        tokenBuilder.AddUsername("testuser");
+
+        // Act
+        var token = tokenBuilder.Build();
+
+        // Assert
+        token.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void Build_ShouldReturnValidTokenStructure()
+    {
+        // Arrange
+        var tokenBuilder = new TokenBuilder(_mockConfiguration.Object);
+        tokenBuilder.AddUsername("testuser");
+
+        // Act
+        var token = tokenBuilder.Build();
+        var parts = token.Split('.');
+
+        // Assert
+        parts.Should().HaveCount(3); // JWT has 3 parts separated by dots
+    }
+
+    [Fact]
+    public void AddClaim_ShouldAddClaimToToken()
+    {
+        // Arrange
+        var tokenBuilder = new TokenBuilder(_mockConfiguration.Object);
+        var claim = new Claim("custom", "value");
+
+        // Act
+        var result = tokenBuilder.AddClaim(claim);
+
+        // Assert
+        result.Should().Be(tokenBuilder);
+    }
+
+    [Fact]
+    public void AddUsername_ShouldReturnSelf()
+    {
+        // Arrange
+        var tokenBuilder = new TokenBuilder(_mockConfiguration.Object);
+
+        // Act
+        var result = tokenBuilder.AddUsername("testuser");
+
+        // Assert
+        result.Should().Be(tokenBuilder);
+    }
+
+    [Fact]
+    public void AddOrUpdateClaim_ShouldReplaceExistingClaim()
+    {
+        // Arrange
+        var tokenBuilder = new TokenBuilder(_mockConfiguration.Object);
+        var claim1 = new Claim("custom", "value1");
+        var claim2 = new Claim("custom", "value2");
+
+        // Act
+        tokenBuilder.AddClaim(claim1);
+        var result = tokenBuilder.AddOrUpdateClaim(claim2);
+
+        // Assert
+        result.Should().Be(tokenBuilder);
+    }
+
+    [Fact]
+    public void RemoveClaim_ShouldRemoveExistingClaim()
+    {
+        // Arrange
+        var tokenBuilder = new TokenBuilder(_mockConfiguration.Object);
+        var claim = new Claim("custom", "value");
+        tokenBuilder.AddClaim(claim);
+
+        // Act
+        var result = tokenBuilder.RemoveClaim(claim);
+
+        // Assert
+        result.Should().Be(tokenBuilder);
+    }
+
+    [Fact]
+    public void FromClaimsPrincipal_ShouldAddAllClaims()
+    {
+        // Arrange
+        var tokenBuilder = new TokenBuilder(_mockConfiguration.Object);
+        var claims = new List<Claim>
+        {
+            new Claim(ClaimTypes.Name, "testuser"),
+            new Claim(ClaimTypes.Email, "test@example.com")
+        };
+        var identity = new ClaimsIdentity(claims, "test");
+        var principal = new ClaimsPrincipal(identity);
+
+        // Act
+        var result = tokenBuilder.FromClaimsPrincipal(principal);
+
+        // Assert
+        result.Should().Be(tokenBuilder);
+    }
+
+    [Fact]
+    public void Build_ShouldIncludeJtiClaim()
+    {
+        // Arrange
+        var tokenBuilder = new TokenBuilder(_mockConfiguration.Object);
+        tokenBuilder.AddUsername("testuser");
+
+        // Act
+        var token = tokenBuilder.Build();
+        var handler = new JwtSecurityTokenHandler();
+        var jwtToken = handler.ReadJwtToken(token);
+
+        // Assert
+        jwtToken.Claims.Should().Contain(c => c.Type == JwtRegisteredClaimNames.Jti);
+    }
+
+    [Fact]
+    public void Build_ShouldIncludeIatClaim()
+    {
+        // Arrange
+        var tokenBuilder = new TokenBuilder(_mockConfiguration.Object);
+        tokenBuilder.AddUsername("testuser");
+
+        // Act
+        var token = tokenBuilder.Build();
+        var handler = new JwtSecurityTokenHandler();
+        var jwtToken = handler.ReadJwtToken(token);
+
+        // Assert
+        jwtToken.Claims.Should().Contain(c => c.Type == JwtRegisteredClaimNames.Iat);
+    }
+
+    [Fact]
+    public void Build_ShouldUseDefaultExpirationWhenNotConfigured()
+    {
+        // Arrange
+        var mockConfig = new Mock<IConfiguration>();
+        mockConfig.Setup(c => c["Authentication:JwtKey"]).Returns("VerySecretKeyThatIsAtLeast32CharactersLong");
+        mockConfig.Setup(c => c["Authentication:JwtIssuer"]).Returns("TestIssuer");
+        mockConfig.Setup(c => c["Authentication:JwtAudience"]).Returns("TestAudience");
+        mockConfig.Setup(c => c["Authentication:ExpirationMinutes"]).Returns((string?)null);
+
+        var tokenBuilder = new TokenBuilder(mockConfig.Object);
+        tokenBuilder.AddUsername("testuser");
+
+        // Act
+        var token = tokenBuilder.Build();
+
+        // Assert
+        token.Should().NotBeNullOrEmpty();
+    }
+}

--- a/tests/Commitments.Infrastructure.Tests/Commitments.Infrastructure.Tests.csproj
+++ b/tests/Commitments.Infrastructure.Tests/Commitments.Infrastructure.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Commitments.Infrastructure\Commitments.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\src\Commitments.Core\Commitments.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Commitments.Infrastructure.Tests/Data/CommitmentsDbContextTests.cs
+++ b/tests/Commitments.Infrastructure.Tests/Data/CommitmentsDbContextTests.cs
@@ -1,0 +1,488 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Commitments.Core.AggregateModel;
+using Commitments.Core.AggregateModel.ActivityAggregate;
+using Commitments.Core.AggregateModel.BehaviourAggregate;
+using Commitments.Core.AggregateModel.BehaviourTypeAggregate;
+using Commitments.Core.AggregateModel.CardAggregate;
+using Commitments.Core.AggregateModel.CardLayoutAggregate;
+using Commitments.Core.AggregateModel.CommitmentAggregate;
+using Commitments.Core.AggregateModel.DashboardAggregate;
+using Commitments.Core.AggregateModel.DashboardCardAggregate;
+using Commitments.Core.AggregateModel.DigitalAssetAggregate;
+using Commitments.Core.AggregateModel.FrequencyAggregate;
+using Commitments.Core.AggregateModel.FrequencyTypeAggregate;
+using Commitments.Core.AggregateModel.UserAggregate;
+using Commitments.Infrastructure.Data;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Commitments.Infrastructure.Tests.Data;
+
+public class CommitmentsDbContextTests : IDisposable
+{
+    private readonly CommitmentsDbContext _context;
+
+    public CommitmentsDbContextTests()
+    {
+        var options = new DbContextOptionsBuilder<CommitmentsDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        _context = new CommitmentsDbContext(options);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    [Fact]
+    public void CommitmentsDbContext_ShouldHaveActivitiesDbSet()
+    {
+        // Assert
+        _context.Activities.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void CommitmentsDbContext_ShouldHaveBehavioursDbSet()
+    {
+        // Assert
+        _context.Behaviours.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void CommitmentsDbContext_ShouldHaveBehaviourTypesDbSet()
+    {
+        // Assert
+        _context.BehaviourTypes.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void CommitmentsDbContext_ShouldHaveCommitmentsDbSet()
+    {
+        // Assert
+        _context.Commitments.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void CommitmentsDbContext_ShouldHaveCommitmentFrequenciesDbSet()
+    {
+        // Assert
+        _context.CommitmentFrequencies.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void CommitmentsDbContext_ShouldHaveFrequenciesDbSet()
+    {
+        // Assert
+        _context.Frequencies.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void CommitmentsDbContext_ShouldHaveFrequencyTypesDbSet()
+    {
+        // Assert
+        _context.FrequencyTypes.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void CommitmentsDbContext_ShouldHaveCardsDbSet()
+    {
+        // Assert
+        _context.Cards.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void CommitmentsDbContext_ShouldHaveCardLayoutsDbSet()
+    {
+        // Assert
+        _context.CardLayouts.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void CommitmentsDbContext_ShouldHaveDashboardsDbSet()
+    {
+        // Assert
+        _context.Dashboards.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void CommitmentsDbContext_ShouldHaveDashboardCardsDbSet()
+    {
+        // Assert
+        _context.DashboardCards.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void CommitmentsDbContext_ShouldHaveProfilesDbSet()
+    {
+        // Assert
+        _context.Profiles.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void CommitmentsDbContext_ShouldHaveUsersDbSet()
+    {
+        // Assert
+        _context.Users.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void CommitmentsDbContext_ShouldHaveDigitalAssetsDbSet()
+    {
+        // Assert
+        _context.DigitalAssets.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task CommitmentsDbContext_ShouldAddAndRetrieveActivity()
+    {
+        // Arrange
+        var activity = new Activity
+        {
+            ActivityId = Guid.NewGuid(),
+            ProfileId = Guid.NewGuid(),
+            BehaviourId = Guid.NewGuid(),
+            PerformedOn = DateTime.UtcNow,
+            Description = "Test Activity"
+        };
+
+        // Act
+        _context.Activities.Add(activity);
+        await _context.SaveChangesAsync();
+
+        // Assert
+        var retrievedActivity = await _context.Activities.FirstOrDefaultAsync(a => a.ActivityId == activity.ActivityId);
+        retrievedActivity.Should().NotBeNull();
+        retrievedActivity!.Description.Should().Be("Test Activity");
+    }
+
+    [Fact]
+    public async Task CommitmentsDbContext_ShouldAddAndRetrieveBehaviour()
+    {
+        // Arrange
+        var behaviour = new Behaviour
+        {
+            BehaviourId = Guid.NewGuid(),
+            Name = "Test Behaviour",
+            Slug = "test-behaviour",
+            Description = "A test behaviour",
+            BehaviourTypeId = Guid.NewGuid()
+        };
+
+        // Act
+        _context.Behaviours.Add(behaviour);
+        await _context.SaveChangesAsync();
+
+        // Assert
+        var retrievedBehaviour = await _context.Behaviours.FirstOrDefaultAsync(b => b.BehaviourId == behaviour.BehaviourId);
+        retrievedBehaviour.Should().NotBeNull();
+        retrievedBehaviour!.Name.Should().Be("Test Behaviour");
+    }
+
+    [Fact]
+    public async Task CommitmentsDbContext_ShouldAddAndRetrieveBehaviourType()
+    {
+        // Arrange
+        var behaviourType = new BehaviourType
+        {
+            BehaviourTypeId = Guid.NewGuid(),
+            Name = "Test Behaviour Type"
+        };
+
+        // Act
+        _context.BehaviourTypes.Add(behaviourType);
+        await _context.SaveChangesAsync();
+
+        // Assert
+        var retrievedBehaviourType = await _context.BehaviourTypes.FirstOrDefaultAsync(bt => bt.BehaviourTypeId == behaviourType.BehaviourTypeId);
+        retrievedBehaviourType.Should().NotBeNull();
+        retrievedBehaviourType!.Name.Should().Be("Test Behaviour Type");
+    }
+
+    [Fact]
+    public async Task CommitmentsDbContext_ShouldAddAndRetrieveCommitment()
+    {
+        // Arrange
+        var commitment = new Commitment
+        {
+            CommitmentId = Guid.NewGuid(),
+            BehaviourId = Guid.NewGuid(),
+            ProfileId = Guid.NewGuid()
+        };
+
+        // Act
+        _context.Commitments.Add(commitment);
+        await _context.SaveChangesAsync();
+
+        // Assert
+        var retrievedCommitment = await _context.Commitments.FirstOrDefaultAsync(c => c.CommitmentId == commitment.CommitmentId);
+        retrievedCommitment.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task CommitmentsDbContext_ShouldAddAndRetrieveFrequency()
+    {
+        // Arrange
+        var frequency = new Frequency
+        {
+            FrequencyId = Guid.NewGuid(),
+            FrequencyTypeId = Guid.NewGuid(),
+            IsDesirable = true
+        };
+
+        // Act
+        _context.Frequencies.Add(frequency);
+        await _context.SaveChangesAsync();
+
+        // Assert
+        var retrievedFrequency = await _context.Frequencies.FirstOrDefaultAsync(f => f.FrequencyId == frequency.FrequencyId);
+        retrievedFrequency.Should().NotBeNull();
+        retrievedFrequency!.IsDesirable.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CommitmentsDbContext_ShouldAddAndRetrieveFrequencyType()
+    {
+        // Arrange
+        var frequencyType = new FrequencyType
+        {
+            FrequencyTypeId = Guid.NewGuid(),
+            Name = "Daily"
+        };
+
+        // Act
+        _context.FrequencyTypes.Add(frequencyType);
+        await _context.SaveChangesAsync();
+
+        // Assert
+        var retrievedFrequencyType = await _context.FrequencyTypes.FirstOrDefaultAsync(ft => ft.FrequencyTypeId == frequencyType.FrequencyTypeId);
+        retrievedFrequencyType.Should().NotBeNull();
+        retrievedFrequencyType!.Name.Should().Be("Daily");
+    }
+
+    [Fact]
+    public async Task CommitmentsDbContext_ShouldAddAndRetrieveCard()
+    {
+        // Arrange
+        var card = new Card
+        {
+            CardId = Guid.NewGuid(),
+            Name = "Test Card",
+            Description = "Test Description"
+        };
+
+        // Act
+        _context.Cards.Add(card);
+        await _context.SaveChangesAsync();
+
+        // Assert
+        var retrievedCard = await _context.Cards.FirstOrDefaultAsync(c => c.CardId == card.CardId);
+        retrievedCard.Should().NotBeNull();
+        retrievedCard!.Name.Should().Be("Test Card");
+    }
+
+    [Fact]
+    public async Task CommitmentsDbContext_ShouldAddAndRetrieveDashboard()
+    {
+        // Arrange
+        var dashboard = new Dashboard("Test Dashboard");
+        dashboard.DashboardId = Guid.NewGuid();
+
+        // Act
+        _context.Dashboards.Add(dashboard);
+        await _context.SaveChangesAsync();
+
+        // Assert
+        var retrievedDashboard = await _context.Dashboards.FirstOrDefaultAsync(d => d.DashboardId == dashboard.DashboardId);
+        retrievedDashboard.Should().NotBeNull();
+        retrievedDashboard!.Name.Should().Be("Test Dashboard");
+    }
+
+    [Fact]
+    public async Task CommitmentsDbContext_ShouldAddAndRetrieveUser()
+    {
+        // Arrange
+        var user = new User
+        {
+            UserId = Guid.NewGuid(),
+            Username = "testuser",
+            FirstName = "Test",
+            LastName = "User",
+            Email = "test@example.com"
+        };
+
+        // Act
+        _context.Users.Add(user);
+        await _context.SaveChangesAsync();
+
+        // Assert
+        var retrievedUser = await _context.Users.FirstOrDefaultAsync(u => u.UserId == user.UserId);
+        retrievedUser.Should().NotBeNull();
+        retrievedUser!.Username.Should().Be("testuser");
+    }
+
+    [Fact]
+    public async Task CommitmentsDbContext_ShouldAddAndRetrieveProfile()
+    {
+        // Arrange
+        var profile = new Profile
+        {
+            ProfileId = Guid.NewGuid()
+        };
+
+        // Act
+        _context.Profiles.Add(profile);
+        await _context.SaveChangesAsync();
+
+        // Assert
+        var retrievedProfile = await _context.Profiles.FirstOrDefaultAsync(p => p.ProfileId == profile.ProfileId);
+        retrievedProfile.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task CommitmentsDbContext_ShouldAddAndRetrieveDigitalAsset()
+    {
+        // Arrange
+        var digitalAsset = new DigitalAsset
+        {
+            DigitalAssetId = Guid.NewGuid(),
+            Name = "test-image.png",
+            ContentType = "image/png",
+            Bytes = new byte[] { 1, 2, 3 }
+        };
+
+        // Act
+        _context.DigitalAssets.Add(digitalAsset);
+        await _context.SaveChangesAsync();
+
+        // Assert
+        var retrievedDigitalAsset = await _context.DigitalAssets.FirstOrDefaultAsync(da => da.DigitalAssetId == digitalAsset.DigitalAssetId);
+        retrievedDigitalAsset.Should().NotBeNull();
+        retrievedDigitalAsset!.Name.Should().Be("test-image.png");
+    }
+
+    [Fact]
+    public async Task CommitmentsDbContext_ShouldSetCreatedOnWhenSaving()
+    {
+        // Arrange
+        var activity = new Activity
+        {
+            ActivityId = Guid.NewGuid(),
+            ProfileId = Guid.NewGuid(),
+            BehaviourId = Guid.NewGuid(),
+            PerformedOn = DateTime.UtcNow,
+            Description = "Test Activity"
+        };
+
+        // Act
+        _context.Activities.Add(activity);
+        await _context.SaveChangesAsync();
+
+        // Assert
+        activity.CreatedOn.Should().NotBe(default);
+    }
+
+    [Fact]
+    public async Task CommitmentsDbContext_ShouldSetLastModifiedOnWhenSaving()
+    {
+        // Arrange
+        var activity = new Activity
+        {
+            ActivityId = Guid.NewGuid(),
+            ProfileId = Guid.NewGuid(),
+            BehaviourId = Guid.NewGuid(),
+            PerformedOn = DateTime.UtcNow,
+            Description = "Test Activity"
+        };
+
+        // Act
+        _context.Activities.Add(activity);
+        await _context.SaveChangesAsync();
+
+        // Assert
+        activity.LastModifiedOn.Should().NotBe(default);
+    }
+
+    [Fact]
+    public async Task CommitmentsDbContext_ShouldSoftDeleteOnRemove()
+    {
+        // Arrange
+        var activity = new Activity
+        {
+            ActivityId = Guid.NewGuid(),
+            ProfileId = Guid.NewGuid(),
+            BehaviourId = Guid.NewGuid(),
+            PerformedOn = DateTime.UtcNow,
+            Description = "Test Activity"
+        };
+
+        _context.Activities.Add(activity);
+        await _context.SaveChangesAsync();
+
+        // Act
+        _context.Activities.Remove(activity);
+        await _context.SaveChangesAsync();
+
+        // Assert
+        // Due to query filters, we need to ignore the filter to check
+        var deletedActivity = await _context.Activities.IgnoreQueryFilters()
+            .FirstOrDefaultAsync(a => a.ActivityId == activity.ActivityId);
+        deletedActivity.Should().NotBeNull();
+        deletedActivity!.IsDeleted.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CommitmentsDbContext_QueryFilter_ShouldExcludeDeletedActivities()
+    {
+        // Arrange
+        var activity = new Activity
+        {
+            ActivityId = Guid.NewGuid(),
+            ProfileId = Guid.NewGuid(),
+            BehaviourId = Guid.NewGuid(),
+            PerformedOn = DateTime.UtcNow,
+            Description = "Test Activity",
+            IsDeleted = true
+        };
+
+        _context.Activities.Add(activity);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var activities = await _context.Activities.ToListAsync();
+
+        // Assert
+        activities.Should().NotContain(a => a.ActivityId == activity.ActivityId);
+    }
+
+    [Fact]
+    public async Task CommitmentsDbContext_ShouldUpdateLastModifiedOnWhenModifying()
+    {
+        // Arrange
+        var activity = new Activity
+        {
+            ActivityId = Guid.NewGuid(),
+            ProfileId = Guid.NewGuid(),
+            BehaviourId = Guid.NewGuid(),
+            PerformedOn = DateTime.UtcNow,
+            Description = "Test Activity"
+        };
+
+        _context.Activities.Add(activity);
+        await _context.SaveChangesAsync();
+
+        var originalModifiedOn = activity.LastModifiedOn;
+        await Task.Delay(10); // Small delay to ensure different timestamp
+
+        // Act
+        activity.Description = "Updated Description";
+        await _context.SaveChangesAsync();
+
+        // Assert
+        activity.LastModifiedOn.Should().BeAfter(originalModifiedOn);
+    }
+}


### PR DESCRIPTION
- Create Commitments.Core.Tests with tests for:
  - Entity models (Commitment, Behaviour, Activity, etc.)
  - DTOs and mapping methods
  - Command handlers and validators
  - Query handlers
  - Services (PasswordHasher, TokenBuilder)
  - Extensions (StringExtensions, HttpContextAccessorExtensions)

- Create Commitments.Infrastructure.Tests with tests for:
  - CommitmentsDbContext operations
  - Entity CRUD operations
  - Soft delete and query filters
  - Audit tracking (CreatedOn, LastModifiedOn)

- Create Commitments.Api.Tests with tests for:
  - CommitmentController
  - ActivityController
  - BehaviourController
  - BehaviourTypeController
  - FrequencyController
  - FrequencyTypeController
  - DashboardController
  - CardController

Test projects use xUnit, Moq, FluentAssertions, and EF Core InMemory.