### PR TITLE
Refactor Profile into ProfileAggregate folder

### DIFF
--- a/src/Commitments.Core/ICommitmentsDbContext.cs
+++ b/src/Commitments.Core/ICommitmentsDbContext.cs
@@ -14,6 +14,7 @@ using Commitments.Core.Model.FrequencyAggregate;
 using Commitments.Core.Model.FrequencyTypeAggregate;
 using Commitments.Core.Model.UserAggregate;
 using Commitments.Core.Model.DigitalAssetAggregate;
+using Commitments.Core.Model.ProfileAggregate;
 using Microsoft.EntityFrameworkCore;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Commitments.Core/Model/ProfileAggregate/Profile.cs
+++ b/src/Commitments.Core/Model/ProfileAggregate/Profile.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-namespace Commitments.Core.Model;
+namespace Commitments.Core.Model.ProfileAggregate;
 
 public class Profile : BaseEntity
 {

--- a/src/Commitments.Infrastructure/Data/CommitmentsDbContext.cs
+++ b/src/Commitments.Infrastructure/Data/CommitmentsDbContext.cs
@@ -15,6 +15,7 @@ using Commitments.Core.Model.FrequencyAggregate;
 using Commitments.Core.Model.FrequencyTypeAggregate;
 using Commitments.Core.Model.UserAggregate;
 using Commitments.Core.Model.DigitalAssetAggregate;
+using Commitments.Core.Model.ProfileAggregate;
 using Commitments.Core.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using System;

--- a/tests/Commitments.Core.Tests/Model/ProfileTests.cs
+++ b/tests/Commitments.Core.Tests/Model/ProfileTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using Commitments.Core.Model;
+using Commitments.Core.Model.ProfileAggregate;
 using FluentAssertions;
 using Xunit;
 


### PR DESCRIPTION
Move Profile.cs to its own ProfileAggregate folder following the existing pattern for other aggregates. Update namespace to match file location and update all references accordingly.