### PR TITLE
Migrate to Angular signals and modern RxJS patterns

### DIFF
--- a/frontend/projects/commitments-app/src/app/app-store.ts
+++ b/frontend/projects/commitments-app/src/app/app-store.ts
@@ -1,11 +1,10 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Injectable } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
+import { Injectable, signal, WritableSignal } from '@angular/core';
 import { Profile } from './models/profile';
 
 @Injectable({ providedIn: 'root' })
 export class AppStore {
-  public currentProfile$: BehaviorSubject<Profile> = new BehaviorSubject(<Profile>{});
+  public readonly currentProfile: WritableSignal<Profile> = signal(<Profile>{});
 }

--- a/frontend/projects/commitments-app/src/app/components/add-tag-dialog/add-tag-dialog.component.ts
+++ b/frontend/projects/commitments-app/src/app/components/add-tag-dialog/add-tag-dialog.component.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Component, inject } from '@angular/core';
+import { Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
-import { Subject } from 'rxjs';
 import { OverlayRefWrapper } from '../../core/overlay-ref-wrapper';
 import { TagsService } from '../../services/tags.service';
 import { FormGroup, FormControl, Validators, ReactiveFormsModule } from '@angular/forms';
 import { Tag } from '../../models/tag';
-import { map, tap, takeUntil } from 'rxjs';
+import { map, tap } from 'rxjs';
 import { Store } from '../../core/store';
 
 @Component({
@@ -22,6 +22,7 @@ export class AddTagDialogComponent {
   private readonly _overlay = inject(OverlayRefWrapper);
   private readonly _store = inject(Store);
   private readonly _tagService = inject(TagsService);
+  private readonly _destroyRef = inject(DestroyRef);
 
   public handleCancel() {
     this._overlay.close();
@@ -31,10 +32,10 @@ export class AddTagDialogComponent {
     this._tagService
       .save({ tag })
       .pipe(
-        takeUntil(this.onDestroy),
+        takeUntilDestroyed(this._destroyRef),
         map((result: any) => {
           tag.tagId = result.tagId;
-          this._store.tags$.next([...this._store.tags$.value, tag]);
+          this._store.tags.update(tags => [...tags, tag]);
         }),
         tap(() => this._overlay.close())
       )
@@ -46,10 +47,4 @@ export class AddTagDialogComponent {
   public form = new FormGroup({
     name: new FormControl(this.tag.name, [Validators.required])
   });
-
-  public onDestroy: Subject<void> = new Subject<void>();
-
-  ngOnDestroy() {
-    this.onDestroy.next();
-  }
 }

--- a/frontend/projects/commitments-app/src/app/components/auto-complete-chip-list/auto-complete-chip-list.component.html
+++ b/frontend/projects/commitments-app/src/app/components/auto-complete-chip-list/auto-complete-chip-list.component.html
@@ -1,7 +1,7 @@
 <mat-form-field>
   <mat-chip-list #chipList>
     <mat-chip color="primary"
-              *ngFor="let item of selectedItems"
+              *ngFor="let item of itemsData"
               (remove)="onRemoveItems(item)"
               (click)="onChipClick.emit({ item: item })"
               >
@@ -15,7 +15,7 @@
            [matAutocomplete]="language"
            [formControl]="addItems" #chipInput />
     <mat-autocomplete #language="matAutocomplete" (optionSelected)="onAddItems($event)">
-      <mat-option *ngFor="let item of filteredItems | async" [value]="item">
+      <mat-option *ngFor="let item of filteredItems()" [value]="item">
         <span>{{ item.name }}</span>
       </mat-option>
     </mat-autocomplete>

--- a/frontend/projects/commitments-app/src/app/components/auto-complete-chip-list/auto-complete-chip-list.component.ts
+++ b/frontend/projects/commitments-app/src/app/components/auto-complete-chip-list/auto-complete-chip-list.component.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Component, Input, Output, EventEmitter, ViewChild, forwardRef } from '@angular/core';
+import { Component, forwardRef, input, output, viewChild } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
-import { Subject, Observable } from 'rxjs';
 import { ControlValueAccessor, FormControl, NG_VALUE_ACCESSOR, ReactiveFormsModule } from '@angular/forms';
 import { startWith, map } from 'rxjs';
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
@@ -34,10 +34,6 @@ import { MatIconModule } from '@angular/material/icon';
   ]
 })
 export class AutoCompleteChipListComponent implements ControlValueAccessor {
-  constructor() {
-    this.onChipClick = new EventEmitter();
-  }
-
   writeValue(obj: any): void {
     obj = this.addItems.value;
   }
@@ -56,67 +52,62 @@ export class AutoCompleteChipListComponent implements ControlValueAccessor {
 
   public onChangeCallback: (_: any) => void = () => {};
 
-  public onDestroy: Subject<void> = new Subject<void>();
+  public readonly onChipClick = output<{ item: any }>();
 
-  ngOnDestroy() {
-    this.onDestroy.next();
-  }
+  public readonly chipInput = viewChild<MatInput>('chipInput');
+  public readonly selectedItems = input<string[]>([]);
+  public readonly items = input<Item[]>([]);
 
-  @Output() public onChipClick: EventEmitter<any>;
-
-  @ViewChild('chipInput') chipInput: MatInput;
-  @Input() selectedItems: string[] = [];
-  filteredItems: Observable<any[]>;
-  addItems: FormControl;
+  public addItems: FormControl = new FormControl();
+  public filteredItems = toSignal(
+    this.addItems.valueChanges.pipe(
+      startWith(''),
+      map(item => (item ? this.filterItems(item.toString()) : this.items().slice()))
+    ),
+    { initialValue: [] as Item[] }
+  );
 
   separatorKeysCodes = [ENTER, COMMA];
 
+  private _localSelected: string[] = [];
+
+  ngOnInit() {
+    this._localSelected = [...(this.selectedItems() ?? [])];
+  }
+
   get itemsData(): string[] {
-    return this.selectedItems;
+    return this._localSelected;
   }
 
   set itemsData(v: string[]) {
-    this.selectedItems = v;
-  }
-
-  @Input() items: Item[] = [];
-
-  ngOnInit() {
-    this.addItems = new FormControl();
-
-    this.filteredItems = this.addItems.valueChanges.pipe(
-      startWith(''),
-      map(item => (item ? this.filterItems(item.toString()) : this.items.slice()))
-    );
+    this._localSelected = v;
   }
 
   filterItems(itemName: string) {
-    return this.items.filter(item => item.name.toLowerCase().indexOf(itemName.toLowerCase()) === 0);
+    return this.items().filter(item => item.name.toLowerCase().indexOf(itemName.toLowerCase()) === 0);
   }
 
   onRemoveItems(itemName: string): void {
-    this.selectedItems = this.selectedItems.filter((name: string) => name !== itemName);
-    this.itemsData = this.selectedItems;
-    this.chipInput['nativeElement'].blur();
-    this.onChangeCallback(this.selectedItems);
+    this._localSelected = this._localSelected.filter(name => name !== itemName);
+    this.chipInput()['nativeElement'].blur();
+    this.onChangeCallback(this._localSelected);
   }
 
   onAddItems(event: MatAutocompleteSelectedEvent) {
     const t: Item = event.option.value;
 
-    if (this.selectedItems.length === 0) {
-      this.selectedItems.push(t.name);
+    if (this._localSelected.length === 0) {
+      this._localSelected.push(t.name);
     } else {
-      const selectLanguageStr = JSON.stringify(this.selectedItems);
+      const selectLanguageStr = JSON.stringify(this._localSelected);
       if (selectLanguageStr.indexOf(t.name) === -1) {
-        this.selectedItems.push(t.name);
+        this._localSelected.push(t.name);
       }
     }
 
-    this.itemsData = this.selectedItems;
-    this.chipInput['nativeElement'].blur();
-    this.chipInput['nativeElement'].value = '';
-    this.onChangeCallback(this.selectedItems);
+    this.chipInput()['nativeElement'].blur();
+    this.chipInput()['nativeElement'].value = '';
+    this.onChangeCallback(this._localSelected);
   }
 }
 

--- a/frontend/projects/commitments-app/src/app/components/checkbox-cell/checkbox-cell.component.ts
+++ b/frontend/projects/commitments-app/src/app/components/checkbox-cell/checkbox-cell.component.ts
@@ -3,7 +3,6 @@
 
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Subject } from 'rxjs';
 import { ICellRendererAngularComp } from 'ag-grid-angular';
 import { ICellRendererParams } from 'ag-grid-community';
 import { MatCheckboxModule } from '@angular/material/checkbox';
@@ -28,11 +27,5 @@ export class CheckboxCellComponent implements ICellRendererAngularComp {
 
   onChange($event) {
     this.params.value = $event;
-  }
-
-  public onDestroy: Subject<void> = new Subject<void>();
-
-  ngOnDestroy() {
-    this.onDestroy.next();
   }
 }

--- a/frontend/projects/commitments-app/src/app/components/create-profile-dialog/create-profile-dialog.component.ts
+++ b/frontend/projects/commitments-app/src/app/components/create-profile-dialog/create-profile-dialog.component.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Component, inject } from '@angular/core';
+import { Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
-import { Subject } from 'rxjs';
 import { FormGroup, FormControl, ReactiveFormsModule } from '@angular/forms';
 import { OverlayRefWrapper } from '../../core/overlay-ref-wrapper';
 import { ProfileService } from '../../services/profile.service';
 import { Profile } from '../../models/profile';
-import { map, tap, takeUntil } from 'rxjs';
+import { tap } from 'rxjs';
 
 @Component({
   selector: 'app-create-profile-dialog',
@@ -20,12 +20,7 @@ import { map, tap, takeUntil } from 'rxjs';
 export class CreateProfileDialogComponent {
   private readonly _profileService = inject(ProfileService);
   private readonly _overlay = inject(OverlayRefWrapper);
-
-  public onDestroy: Subject<void> = new Subject<void>();
-
-  ngOnDestroy() {
-    this.onDestroy.next();
-  }
+  private readonly _destroyRef = inject(DestroyRef);
 
   public handleCancelClick() {
     this._overlay.close();
@@ -45,9 +40,11 @@ export class CreateProfileDialogComponent {
     profile.name = options.name;
     this._profileService.create(options)
       .pipe(
-        map(x => profile.profileId = x.profileId),
-        tap(x => this._overlay.close(profile)),
-        takeUntil(this.onDestroy)
+        takeUntilDestroyed(this._destroyRef),
+        tap(x => {
+          profile.profileId = x.profileId;
+          this._overlay.close(profile);
+        })
       )
       .subscribe();
   }

--- a/frontend/projects/commitments-app/src/app/components/delete-cell/delete-cell.component.ts
+++ b/frontend/projects/commitments-app/src/app/components/delete-cell/delete-cell.component.ts
@@ -3,7 +3,6 @@
 
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Subject } from 'rxjs';
 import { ICellRendererAngularComp } from 'ag-grid-angular';
 import { IAfterGuiAttachedParams, ICellRendererParams } from 'ag-grid-community';
 import { MatIconModule } from '@angular/material/icon';
@@ -23,10 +22,4 @@ export class DeleteCellComponent implements ICellRendererAngularComp {
   agInit(_params: ICellRendererParams): void {}
 
   afterGuiAttached?(_params?: IAfterGuiAttachedParams): void {}
-
-  public onDestroy: Subject<void> = new Subject<void>();
-
-  ngOnDestroy() {
-    this.onDestroy.next();
-  }
 }

--- a/frontend/projects/commitments-app/src/app/components/digital-asset-url-input/digital-asset-url-input.component.html
+++ b/frontend/projects/commitments-app/src/app/components/digital-asset-url-input/digital-asset-url-input.component.html
@@ -1,3 +1,3 @@
 <mat-form-field>
-  <input matInput type="text" placeholder="{{ placeholder }}" />
+  <input matInput type="text" placeholder="{{ placeholder() }}" />
 </mat-form-field>

--- a/frontend/projects/commitments-app/src/app/components/digital-asset-url-input/digital-asset-url-input.component.ts
+++ b/frontend/projects/commitments-app/src/app/components/digital-asset-url-input/digital-asset-url-input.component.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Component, ElementRef, Input, forwardRef, inject } from '@angular/core';
+import { Component, ElementRef, forwardRef, inject, input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { DigitalAssetService } from '../../services/digital-asset.service';
@@ -85,8 +85,7 @@ export class DigitalAssetInputUrlComponent implements ControlValueAccessor {
     }
   }
 
-  @Input()
-  public placeholder: string;
+  public readonly placeholder = input<string>('');
 
   public get inputElement(): HTMLInputElement { return this._elementRef.nativeElement.querySelector('input'); }
 }

--- a/frontend/projects/commitments-app/src/app/components/edit-activity-dialog/edit-activity-dialog.component.ts
+++ b/frontend/projects/commitments-app/src/app/components/edit-activity-dialog/edit-activity-dialog.component.ts
@@ -1,15 +1,15 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Component, inject } from '@angular/core';
+import { Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
-import { Subject, Observable } from 'rxjs';
 import { BehaviourService } from '../../services/behaviour.service';
 import { Behaviour } from '../../models/behaviour';
 import { ActivityService } from '../../services/activity.service';
 import { OverlayRefWrapper } from '../../core/overlay-ref-wrapper';
 import { Activity } from '../../models/activity';
-import { takeUntil, map } from 'rxjs';
+import { tap } from 'rxjs';
 import { FormGroup, FormControl, Validators, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatInputModule } from '@angular/material/input';
@@ -36,8 +36,11 @@ export class EditActivityDialogComponent {
   private readonly _activityService = inject(ActivityService);
   private readonly _behaviourService = inject(BehaviourService);
   private readonly _overlay = inject(OverlayRefWrapper);
+  private readonly _destroyRef = inject(DestroyRef);
 
   public activityId: number;
+
+  public readonly behaviours = toSignal(this._behaviourService.get(), { initialValue: [] as Array<Behaviour> });
 
   public handleSaveClick() {
     const activity = new Activity();
@@ -48,10 +51,13 @@ export class EditActivityDialogComponent {
     activity.description = this.form.value.description;
 
     this._activityService.save({ activity })
-      .pipe(map((x: { activityId: number }) => {
-        activity.activityId = x.activityId;
-        this._overlay.close(activity);
-      }), takeUntil(this.onDestroy))
+      .pipe(
+        takeUntilDestroyed(this._destroyRef),
+        tap((x: { activityId: number }) => {
+          activity.activityId = x.activityId;
+          this._overlay.close(activity);
+        })
+      )
       .subscribe();
   }
 
@@ -60,23 +66,16 @@ export class EditActivityDialogComponent {
   }
 
   ngOnInit() {
-    this.behaviours$ = this._behaviourService.get();
-
     this._activityService.getById({ activityId: this.activityId })
-      .pipe(map(x => this.form.patchValue({
-        performedOn: x.performedOn,
-        behaviourId: x.behaviourId,
-        description: x.description
-      })))
+      .pipe(
+        takeUntilDestroyed(this._destroyRef),
+        tap(x => this.form.patchValue({
+          performedOn: x.performedOn,
+          behaviourId: x.behaviourId,
+          description: x.description
+        }))
+      )
       .subscribe();
-  }
-
-  public behaviours$: Observable<Array<Behaviour>>;
-
-  public onDestroy: Subject<void> = new Subject<void>();
-
-  ngOnDestroy() {
-    this.onDestroy.next();
   }
 
   public form: FormGroup = new FormGroup({

--- a/frontend/projects/commitments-app/src/app/components/edit-activity-dialog/edit-activity-dialog.html
+++ b/frontend/projects/commitments-app/src/app/components/edit-activity-dialog/edit-activity-dialog.html
@@ -6,7 +6,7 @@
 
   <mat-form-field>
     <mat-select placeholder="Behaviour" formControlName="behaviourId" name="behaviourId">
-      <mat-option *ngFor="let behaviour of (behaviours$ | async)" [value]="behaviour.behaviourId">
+      <mat-option *ngFor="let behaviour of behaviours()" [value]="behaviour.behaviourId">
         {{ behaviour.name }}
       </mat-option>
     </mat-select>

--- a/frontend/projects/commitments-app/src/app/components/edit-behaviour-dialog/edit-behaviour-dialog.component.ts
+++ b/frontend/projects/commitments-app/src/app/components/edit-behaviour-dialog/edit-behaviour-dialog.component.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Component, inject } from '@angular/core';
+import { Component, DestroyRef, inject, signal } from '@angular/core';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
-import { Subject, BehaviorSubject, Observable } from 'rxjs';
 import { FormGroup, FormControl, Validators, ReactiveFormsModule } from '@angular/forms';
 import { OverlayRefWrapper } from '../../core/overlay-ref-wrapper';
 import { BehaviourService } from '../../services/behaviour.service';
 import { Behaviour } from '../../models/behaviour';
-import { map, switchMap, tap, takeUntil } from 'rxjs';
+import { tap } from 'rxjs';
 import { BehaviourType } from '../../models/behaviour-type';
 import { BehaviourTypeService } from '../../services/behaviour-type.service';
 
@@ -23,34 +23,31 @@ export class EditBehaviourDialogComponent {
   private readonly _behaviourService = inject(BehaviourService);
   private readonly _behaviourTypeService = inject(BehaviourTypeService);
   private readonly _overlay = inject(OverlayRefWrapper);
+  private readonly _destroyRef = inject(DestroyRef);
 
-  public behaviourTypes$: Observable<BehaviourType[]>;
-
-  ngOnInit() {
-    this.behaviourTypes$ = this._behaviourTypeService.get();
-
-    if (this.behaviourId)
-      this._behaviourService.getById({ behaviourId: this.behaviourId })
-        .pipe(
-          map(x => this.behaviour$.next(x)),
-          switchMap(x => this.behaviour$),
-          map(x => this.form.patchValue({
-            name: x.name,
-            description: x.description,
-            behaviourTypeId: x.behaviourTypeId,
-            isDesired: x.isDesired
-          }))
-        )
-        .subscribe();
-  }
-
-  public onDestroy: Subject<void> = new Subject<void>();
-
-  ngOnDestroy() { this.onDestroy.next(); }
-
-  public behaviour$: BehaviorSubject<Behaviour> = new BehaviorSubject(<Behaviour>{});
+  public readonly behaviourTypes = toSignal(this._behaviourTypeService.get(), { initialValue: [] as BehaviourType[] });
+  public readonly behaviour = signal<Behaviour>(<Behaviour>{});
 
   public behaviourId: number;
+
+  ngOnInit() {
+    if (this.behaviourId) {
+      this._behaviourService.getById({ behaviourId: this.behaviourId })
+        .pipe(
+          takeUntilDestroyed(this._destroyRef),
+          tap(x => {
+            this.behaviour.set(x);
+            this.form.patchValue({
+              name: x.name,
+              description: x.description,
+              behaviourTypeId: x.behaviourTypeId,
+              isDesired: x.isDesired
+            });
+          })
+        )
+        .subscribe();
+    }
+  }
 
   public handleCancelClick() { this._overlay.close(); }
 
@@ -63,9 +60,11 @@ export class EditBehaviourDialogComponent {
 
     this._behaviourService.save({ behaviour })
       .pipe(
-        map(x => behaviour.behaviourId = x.behaviourId),
-        tap(x => this._overlay.close(behaviour)),
-        takeUntil(this.onDestroy)
+        takeUntilDestroyed(this._destroyRef),
+        tap(x => {
+          behaviour.behaviourId = x.behaviourId;
+          this._overlay.close(behaviour);
+        })
       )
       .subscribe();
   }

--- a/frontend/projects/commitments-app/src/app/components/edit-behaviour-dialog/edit-behaviour-dialog.html
+++ b/frontend/projects/commitments-app/src/app/components/edit-behaviour-dialog/edit-behaviour-dialog.html
@@ -5,7 +5,7 @@
 <form class="page-content-container" novalidate autocomplete="off" spellcheck="false" [formGroup]="form">
   <mat-form-field>
     <mat-select placeholder="Behaviour Type" formControlName="behaviourTypeId" name="behaviourTypeId">
-      <mat-option *ngFor="let behaviourType of (behaviourTypes$ | async)" [value]="behaviourType.behaviourTypeId">
+      <mat-option *ngFor="let behaviourType of behaviourTypes()" [value]="behaviourType.behaviourTypeId">
         {{ behaviourType.name }}
       </mat-option>
     </mat-select>

--- a/frontend/projects/commitments-app/src/app/components/edit-behaviour-type-dialog/edit-behaviour-type-dialog.component.ts
+++ b/frontend/projects/commitments-app/src/app/components/edit-behaviour-type-dialog/edit-behaviour-type-dialog.component.ts
@@ -3,7 +3,6 @@
 
 import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Subject } from 'rxjs';
 import { OverlayRefWrapper } from '../../core/overlay-ref-wrapper';
 
 @Component({
@@ -16,17 +15,11 @@ import { OverlayRefWrapper } from '../../core/overlay-ref-wrapper';
 export class EditBehaviourTypeDialogComponent {
   private readonly _overlay = inject(OverlayRefWrapper);
 
-  public onDestroy: Subject<void> = new Subject<void>();
-
   public behaviourTypeId: number;
 
   public handleSaveClick() {}
 
   public handleCancelClick() {
     this._overlay.close();
-  }
-
-  ngOnDestroy() {
-    this.onDestroy.next();
   }
 }

--- a/frontend/projects/commitments-app/src/app/components/edit-card-dialog/edit-card-dialog.component.ts
+++ b/frontend/projects/commitments-app/src/app/components/edit-card-dialog/edit-card-dialog.component.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Component, inject } from '@angular/core';
+import { Component, DestroyRef, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
-import { Subject, BehaviorSubject } from 'rxjs';
 import { FormGroup, FormControl, ReactiveFormsModule } from '@angular/forms';
 import { OverlayRefWrapper } from '../../core/overlay-ref-wrapper';
 import { CardService } from '../../services/card.service';
 import { Card } from '../../models/card';
-import { map, switchMap, tap, takeUntil } from 'rxjs';
+import { tap } from 'rxjs';
 
 @Component({
   selector: 'app-edit-card-dialog',
@@ -20,30 +20,28 @@ import { map, switchMap, tap, takeUntil } from 'rxjs';
 export class EditCardDialogComponent {
   private readonly _cardService = inject(CardService);
   private readonly _overlay = inject(OverlayRefWrapper);
+  private readonly _destroyRef = inject(DestroyRef);
 
-  ngOnInit() {
-    if (this.cardId)
-      this._cardService.getById({ cardId: this.cardId })
-        .pipe(
-          map(x => this.card$.next(x)),
-          switchMap(x => this.card$),
-          map(x => this.form.patchValue({
-            name: x.name,
-            description: x.description
-          }))
-        )
-        .subscribe();
-  }
-
-  public onDestroy: Subject<void> = new Subject<void>();
-
-  ngOnDestroy() {
-    this.onDestroy.next();
-  }
-
-  public card$: BehaviorSubject<Card> = new BehaviorSubject(<Card>{});
+  public readonly card = signal<Card>(<Card>{});
 
   public cardId: number;
+
+  ngOnInit() {
+    if (this.cardId) {
+      this._cardService.getById({ cardId: this.cardId })
+        .pipe(
+          takeUntilDestroyed(this._destroyRef),
+          tap(x => {
+            this.card.set(x);
+            this.form.patchValue({
+              name: x.name,
+              description: x.description
+            });
+          })
+        )
+        .subscribe();
+    }
+  }
 
   public handleCancelClick() {
     this._overlay.close();
@@ -56,9 +54,11 @@ export class EditCardDialogComponent {
     card.name = this.form.value.name;
     this._cardService.save({ card })
       .pipe(
-        map(x => card.cardId = x.cardId),
-        tap(x => this._overlay.close(card)),
-        takeUntil(this.onDestroy)
+        takeUntilDestroyed(this._destroyRef),
+        tap(x => {
+          card.cardId = x.cardId;
+          this._overlay.close(card);
+        })
       )
       .subscribe();
   }

--- a/frontend/projects/commitments-app/src/app/components/edit-card-layout-dialog/edit-card-layout-dialog.component.ts
+++ b/frontend/projects/commitments-app/src/app/components/edit-card-layout-dialog/edit-card-layout-dialog.component.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Component, inject } from '@angular/core';
+import { Component, DestroyRef, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
-import { Subject, BehaviorSubject } from 'rxjs';
 import { FormGroup, FormControl, ReactiveFormsModule } from '@angular/forms';
 import { OverlayRefWrapper } from '../../core/overlay-ref-wrapper';
 import { CardLayoutService } from '../../services/card-layout.service';
 import { CardLayout } from '../../models/card-layout';
-import { map, switchMap, tap, takeUntil } from 'rxjs';
+import { tap } from 'rxjs';
 
 @Component({
   selector: 'app-edit-card-layout-dialog',
@@ -20,29 +20,25 @@ import { map, switchMap, tap, takeUntil } from 'rxjs';
 export class EditCardLayoutDialogComponent {
   private readonly _cardLayoutService = inject(CardLayoutService);
   private readonly _overlay = inject(OverlayRefWrapper);
+  private readonly _destroyRef = inject(DestroyRef);
 
-  ngOnInit() {
-    if (this.cardLayoutId)
-      this._cardLayoutService.getById({ cardLayoutId: this.cardLayoutId })
-        .pipe(
-          map(x => this.cardLayout$.next(x)),
-          switchMap(x => this.cardLayout$),
-          map(x => this.form.patchValue({
-            name: x.name
-          }))
-        )
-        .subscribe();
-  }
-
-  public onDestroy: Subject<void> = new Subject<void>();
-
-  ngOnDestroy() {
-    this.onDestroy.next();
-  }
-
-  public cardLayout$: BehaviorSubject<CardLayout> = new BehaviorSubject(<CardLayout>{});
+  public readonly cardLayout = signal<CardLayout>(<CardLayout>{});
 
   public cardLayoutId: number;
+
+  ngOnInit() {
+    if (this.cardLayoutId) {
+      this._cardLayoutService.getById({ cardLayoutId: this.cardLayoutId })
+        .pipe(
+          takeUntilDestroyed(this._destroyRef),
+          tap(x => {
+            this.cardLayout.set(x);
+            this.form.patchValue({ name: x.name });
+          })
+        )
+        .subscribe();
+    }
+  }
 
   public handleCancelClick() {
     this._overlay.close();
@@ -54,9 +50,11 @@ export class EditCardLayoutDialogComponent {
     cardLayout.name = this.form.value.name;
     this._cardLayoutService.save({ cardLayout })
       .pipe(
-        map(x => cardLayout.cardLayoutId = x.cardLayoutId),
-        tap(x => this._overlay.close(cardLayout)),
-        takeUntil(this.onDestroy)
+        takeUntilDestroyed(this._destroyRef),
+        tap(x => {
+          cardLayout.cardLayoutId = x.cardLayoutId;
+          this._overlay.close(cardLayout);
+        })
       )
       .subscribe();
   }

--- a/frontend/projects/commitments-app/src/app/components/edit-cell/edit-cell.component.ts
+++ b/frontend/projects/commitments-app/src/app/components/edit-cell/edit-cell.component.ts
@@ -3,7 +3,6 @@
 
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Subject } from 'rxjs';
 import { ICellRendererAngularComp } from 'ag-grid-angular';
 import { ICellRendererParams } from 'ag-grid-community';
 import { MatIconModule } from '@angular/material/icon';
@@ -21,10 +20,4 @@ export class EditCellComponent implements ICellRendererAngularComp {
   }
 
   agInit(_params: ICellRendererParams): void {}
-
-  public onDestroy: Subject<void> = new Subject<void>();
-
-  ngOnDestroy() {
-    this.onDestroy.next();
-  }
 }

--- a/frontend/projects/commitments-app/src/app/components/edit-commitment-dialog/edit-commitment-dialog.component.ts
+++ b/frontend/projects/commitments-app/src/app/components/edit-commitment-dialog/edit-commitment-dialog.component.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Component, ViewChild, inject } from '@angular/core';
+import { Component, DestroyRef, inject, viewChild } from '@angular/core';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
-import { Subject, Observable } from 'rxjs';
 import { OverlayRefWrapper } from '../../core/overlay-ref-wrapper';
 import { CommitmentService } from '../../services/commitment.service';
 import { Commitment } from '../../models/commitment';
@@ -13,7 +13,7 @@ import { FormGroup, FormControl, ReactiveFormsModule } from '@angular/forms';
 import { Frequency } from '../../models/frequency';
 import { CommitmentFrequency } from '../../models/commitment-frequency';
 import { FrequencyService } from '../../services/frequency.service';
-import { map, takeUntil } from 'rxjs';
+import { tap } from 'rxjs';
 
 @Component({
   selector: 'app-edit-commitment-dialog',
@@ -27,21 +27,14 @@ export class EditCommitmentDialogComponent {
   private readonly _behaviourService = inject(BehaviourService);
   private readonly _commitmentService = inject(CommitmentService);
   private readonly _frequencyService = inject(FrequencyService);
+  private readonly _destroyRef = inject(DestroyRef);
 
-  ngOnInit() {
-    this.behaviours$ = this._behaviourService.get();
-    this.frequencies$ = this._frequencyService.get();
-  }
+  public readonly behaviours = toSignal(this._behaviourService.get(), { initialValue: [] as Array<Behaviour> });
+  public readonly frequencies = toSignal(this._frequencyService.get(), { initialValue: [] as Array<Frequency> });
 
   public commitmentId: number;
 
   private readonly _commitment = new Commitment();
-
-  public onDestroy: Subject<void> = new Subject<void>();
-
-  ngOnDestroy() {
-    this.onDestroy.next();
-  }
 
   public handleCancelClick() {
     this._overlay.close();
@@ -51,15 +44,18 @@ export class EditCommitmentDialogComponent {
     console.log($event);
   }
 
-  public handleSaveClick(behaviours) {
-    this._commitment.commitmentFrequencies = this.frequencies.selectedOptions.selected.map(x => new CommitmentFrequency(x.value.frequencyId, 0));
-    this._commitment.behaviourId = this.behaviours.selectedOptions.selected.map(x => x.value.behaviourId)[0];
+  public handleSaveClick() {
+    this._commitment.commitmentFrequencies = this.frequenciesList()?.selectedOptions.selected.map(x => new CommitmentFrequency(x.value.frequencyId, 0));
+    this._commitment.behaviourId = this.behavioursList()?.selectedOptions.selected.map(x => x.value.behaviourId)[0];
 
     this._commitmentService.save({ commitment: this._commitment })
-      .pipe(map(x => {
-        this._commitment.commitmentId = x.commitmentId;
-        this._overlay.close(this._commitment);
-      }), takeUntil(this.onDestroy))
+      .pipe(
+        takeUntilDestroyed(this._destroyRef),
+        tap(x => {
+          this._commitment.commitmentId = x.commitmentId;
+          this._overlay.close(this._commitment);
+        })
+      )
       .subscribe();
   }
 
@@ -67,15 +63,8 @@ export class EditCommitmentDialogComponent {
     //this._commitment.frequencies = frequencies.map(x => new CommitmentFrequency());
   }
 
-  @ViewChild('behaviours')
-  public behaviours: any;
-
-  @ViewChild('frequencies')
-  public frequencies: any;
-
-  public behaviours$: Observable<Array<Behaviour>>;
-  public frequencies$: Observable<Array<Frequency>>;
-  public commitments$: Observable<Array<Commitment>>;
+  public readonly behavioursList = viewChild<any>('behaviours');
+  public readonly frequenciesList = viewChild<any>('frequencies');
 
   public form: FormGroup = new FormGroup({
     behaviourId: new FormControl(null, []),

--- a/frontend/projects/commitments-app/src/app/components/edit-commitment-dialog/edit-commitment-dialog.html
+++ b/frontend/projects/commitments-app/src/app/components/edit-commitment-dialog/edit-commitment-dialog.html
@@ -6,7 +6,7 @@
   <mat-tab label="Select Behaviour">
     <section>
       <mat-selection-list #behaviours>
-        <mat-list-option *ngFor="let behaviour of (behaviours$ |async)" [value]="behaviour">
+        <mat-list-option *ngFor="let behaviour of behaviours()" [value]="behaviour">
           {{ behaviour.name }}
         </mat-list-option>
       </mat-selection-list>
@@ -16,7 +16,7 @@
   <mat-tab label="Select Frequencies">
     <section>
       <mat-selection-list #frequencies>
-        <mat-list-option *ngFor="let frequency of (frequencies$ |async)" [value]="frequency" (change)="onNgModelChange($event)">
+        <mat-list-option *ngFor="let frequency of frequencies()" [value]="frequency" (change)="onNgModelChange($event)">
           {{ frequency.frequency }} {{ frequency.frequencyType.name }}
         </mat-list-option>
       </mat-selection-list>
@@ -25,7 +25,7 @@
 </mat-tab-group>
 
 <div class="actions">
-  <button mat-button (click)="handleSaveClick(behaviours)">Save</button>
+  <button mat-button (click)="handleSaveClick()">Save</button>
   <button mat-button (click)="handleCancelClick()">Cancel</button>
 </div>
 

--- a/frontend/projects/commitments-app/src/app/components/edit-frequency-dialog/edit-frequency-dialog.component.ts
+++ b/frontend/projects/commitments-app/src/app/components/edit-frequency-dialog/edit-frequency-dialog.component.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Component, inject } from '@angular/core';
+import { Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
-import { Subject, Observable } from 'rxjs';
 import { FrequencyType } from '../../models/frequency-type';
 import { OverlayRefWrapper } from '../../core/overlay-ref-wrapper';
 import { FrequencyTypeService } from '../../services/frequency-type.service';
 import { FrequencyService } from '../../services/frequency.service';
-import { map } from 'rxjs';
+import { tap } from 'rxjs';
 
 @Component({
   selector: 'app-edit-frequency-dialog',
@@ -21,27 +21,21 @@ export class EditFrequencyDialogComponent {
   public _overlay = inject(OverlayRefWrapper);
   public frequencyTypeService = inject(FrequencyTypeService);
   public frequencyService = inject(FrequencyService);
+  private readonly _destroyRef = inject(DestroyRef);
 
-  ngOnInit() {
-    this.frequencyTypes$ = this.frequencyTypeService.get();
-  }
+  public readonly frequencyTypes = toSignal(this.frequencyTypeService.get(), { initialValue: [] as Array<FrequencyType> });
 
   public frequencyId: number;
 
-  public frequencyTypes$: Observable<Array<FrequencyType>>;
-
   public handleSave($event) {
     this.frequencyService.save({ frequency: $event.frequency })
-      .pipe(map(x => {
-        $event.frequency.frequencyId = x.frequencyId;
-        this._overlay.close($event.frequency);
-      }))
+      .pipe(
+        takeUntilDestroyed(this._destroyRef),
+        tap(x => {
+          $event.frequency.frequencyId = x.frequencyId;
+          this._overlay.close($event.frequency);
+        })
+      )
       .subscribe();
-  }
-
-  public onDestroy: Subject<void> = new Subject<void>();
-
-  ngOnDestroy() {
-    this.onDestroy.next();
   }
 }

--- a/frontend/projects/commitments-app/src/app/components/edit-frequency-dialog/edit-frequency-dialog.html
+++ b/frontend/projects/commitments-app/src/app/components/edit-frequency-dialog/edit-frequency-dialog.html
@@ -1,2 +1,2 @@
-<app-frequency-editor [frequencyTypes]="frequencyTypes$ | async"
+<app-frequency-editor [frequencyTypes]="frequencyTypes()"
                       (save)="handleSave($event)"></app-frequency-editor>

--- a/frontend/projects/commitments-app/src/app/components/edit-to-do-dialog/edit-to-do-dialog.component.ts
+++ b/frontend/projects/commitments-app/src/app/components/edit-to-do-dialog/edit-to-do-dialog.component.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Component, inject } from '@angular/core';
+import { Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
-import { Subject } from 'rxjs';
 import { ToDoService } from '../../services/to-do.service';
 import { ToDo } from '../../models/to-do';
 import { FormGroup, FormControl, Validators, ReactiveFormsModule } from '@angular/forms';
-import { map, takeUntil, tap } from 'rxjs';
+import { tap } from 'rxjs';
 import { OverlayRefWrapper } from '../../core/overlay-ref-wrapper';
 
 @Component({
@@ -20,18 +20,23 @@ import { OverlayRefWrapper } from '../../core/overlay-ref-wrapper';
 export class EditToDoDialogComponent {
   private readonly _overlay = inject(OverlayRefWrapper);
   private readonly _toDoService = inject(ToDoService);
+  private readonly _destroyRef = inject(DestroyRef);
 
   public ngOnInit() {
-    if (this.toDoId)
+    if (this.toDoId) {
       this._toDoService
         .getById({ toDoId: this.toDoId })
-        .pipe(map(toDo => this.form.patchValue({
-          name: toDo.name,
-          description: toDo.description,
-          dueOn: toDo.dueOn,
-          completedOn: toDo.completedOn
-        })), takeUntil(this.onDestroy))
+        .pipe(
+          takeUntilDestroyed(this._destroyRef),
+          tap(toDo => this.form.patchValue({
+            name: toDo.name,
+            description: toDo.description,
+            dueOn: toDo.dueOn,
+            completedOn: toDo.completedOn
+          }))
+        )
         .subscribe();
+    }
   }
 
   public handleSaveClick() {
@@ -44,21 +49,17 @@ export class EditToDoDialogComponent {
     toDo.isCompleted = !this.form.value.completedOn;
     this._toDoService.save({ toDo })
       .pipe(
-        map(x => toDo.toDoId = x.toDoId),
-        tap(x => this._overlay.close(toDo)),
-        takeUntil(this.onDestroy)
+        takeUntilDestroyed(this._destroyRef),
+        tap(x => {
+          toDo.toDoId = x.toDoId;
+          this._overlay.close(toDo);
+        })
       )
       .subscribe();
   }
 
   public handleCancelClick() {
     this._overlay.close();
-  }
-
-  public onDestroy: Subject<void> = new Subject<void>();
-
-  ngOnDestroy() {
-    this.onDestroy.next();
   }
 
   public toDoId: number;

--- a/frontend/projects/commitments-app/src/app/components/frequencies-editor/frequencies-editor.component.html
+++ b/frontend/projects/commitments-app/src/app/components/frequencies-editor/frequencies-editor.component.html
@@ -1,11 +1,11 @@
-<app-frequency-editor [frequencyTypes]="frequencyTypes"
+<app-frequency-editor [frequencyTypes]="frequencyTypes()"
                       (save)="handleFrequencySave($event)">
 
 </app-frequency-editor>
 
 <ag-grid-angular class="ag-theme-material"
                  [columnDefs]="columnDefs"
-                 [rowData]="frequencies$ | async"
+                 [rowData]="rows"
                  (gridReady)="onGridReady($event)">
 </ag-grid-angular>
 

--- a/frontend/projects/commitments-app/src/app/components/frequencies-editor/frequencies-editor.component.ts
+++ b/frontend/projects/commitments-app/src/app/components/frequencies-editor/frequencies-editor.component.ts
@@ -1,9 +1,8 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Component, Input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Subject, BehaviorSubject } from 'rxjs';
 import { FrequencyType } from '../../models/frequency-type';
 import { Frequency } from '../../models/frequency';
 import { ColDef } from 'ag-grid-community';
@@ -17,23 +16,21 @@ import { DeleteCellComponent } from '../delete-cell/delete-cell.component';
   styleUrls: ['./frequencies-editor.component.scss']
 })
 export class FrequenciesEditorComponent {
-  public onDestroy: Subject<void> = new Subject<void>();
+  public readonly frequencyTypes = input<Array<FrequencyType>>([]);
+  public readonly frequencies = input<Array<Frequency>>([]);
 
-  ngOnDestroy() {
-    this.onDestroy.next();
+  private _local: Array<Frequency> = [];
+
+  ngOnInit() {
+    this._local = [...(this.frequencies() ?? [])];
   }
 
-  @Input()
-  public frequencyTypes: Array<FrequencyType> = [];
-
-  @Input()
-  public frequencies$: BehaviorSubject<Array<Frequency>> = new BehaviorSubject([]);
-
-  @Input()
-  public frequencies: any[] = [];
+  public get rows(): Array<Frequency> {
+    return this._local;
+  }
 
   public handleFrequencySave($event) {
-    this.frequencies$.next([...this.frequencies$.value, $event.frequency]);
+    this._local = [...this._local, $event.frequency];
   }
 
   public onGridReady(params) {
@@ -43,10 +40,9 @@ export class FrequenciesEditorComponent {
   public handleSaveClick() {}
 
   public remove($event) {
-    const frequencies: any[] = [...this.frequencies$.value];
-    const index = frequencies.findIndex(x => x.frequency == $event.data.frequency && x.frequencyTypeId == $event.data.frequencyTypeId);
-    frequencies.splice(index, 1);
-    this.frequencies$.next(frequencies);
+    this._local = this._local.filter(
+      x => !(x.frequency == $event.data.frequency && x.frequencyTypeId == $event.data.frequencyTypeId)
+    );
   }
 
   public columnDefs: Array<ColDef> = [

--- a/frontend/projects/commitments-app/src/app/components/frequency-editor/frequency-editor.component.html
+++ b/frontend/projects/commitments-app/src/app/components/frequency-editor/frequency-editor.component.html
@@ -5,7 +5,7 @@
 
   <mat-form-field>
     <mat-select placeholder="Frequency Type" formControlName="frequencyTypeId" name="frequencyTypeId">
-      <mat-option *ngFor="let frequencyType of frequencyTypes" [value]="frequencyType.frequencyTypeId">
+      <mat-option *ngFor="let frequencyType of frequencyTypes()" [value]="frequencyType.frequencyTypeId">
         {{ frequencyType.name }}
       </mat-option>
     </mat-select>

--- a/frontend/projects/commitments-app/src/app/components/frequency-editor/frequency-editor.component.ts
+++ b/frontend/projects/commitments-app/src/app/components/frequency-editor/frequency-editor.component.ts
@@ -1,9 +1,8 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Component, Input, EventEmitter, Output } from '@angular/core';
+import { Component, input, output } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Subject } from 'rxjs';
 import { FormGroup, FormControl, Validators, ReactiveFormsModule } from '@angular/forms';
 import { Frequency } from '../../models/frequency';
 import { FrequencyType } from '../../models/frequency-type';
@@ -16,16 +15,11 @@ import { FrequencyType } from '../../models/frequency-type';
   styleUrls: ['./frequency-editor.component.scss']
 })
 export class FrequencyEditorComponent {
-  public onDestroy: Subject<void> = new Subject<void>();
-
   public frequency: number;
 
-  @Input()
-  public frequencyTypes: Array<FrequencyType> = [];
+  public readonly frequencyTypes = input<Array<FrequencyType>>([]);
 
-  ngOnDestroy() {
-    this.onDestroy.next();
-  }
+  public readonly save = output<{ frequency: Frequency }>();
 
   public handleSaveClick() {
     const frequency = new Frequency();
@@ -34,9 +28,6 @@ export class FrequencyEditorComponent {
     frequency.isDesired = this.form.value.isDesired;
     this.save.emit({ frequency });
   }
-
-  @Output()
-  public save: EventEmitter<any> = new EventEmitter();
 
   public form: FormGroup = new FormGroup({
     frequency: new FormControl(null, [Validators.required]),

--- a/frontend/projects/commitments-app/src/app/components/master-page/master-page.component.html
+++ b/frontend/projects/commitments-app/src/app/components/master-page/master-page.component.html
@@ -6,7 +6,7 @@
 
   <h1>Commitments</h1>
 
-  <a class="profile-name" (click)="onProfileNameClick()">{{ profileName$ | async }}</a>
+  <a class="profile-name" (click)="onProfileNameClick()">{{ profileName() }}</a>
   <div mat-card-avatar class="header-image">&nbsp;</div>
 
 </mat-toolbar>

--- a/frontend/projects/commitments-app/src/app/components/master-page/master-page.component.ts
+++ b/frontend/projects/commitments-app/src/app/components/master-page/master-page.component.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Component, ElementRef, inject } from '@angular/core';
-import { CommonModule, AsyncPipe } from '@angular/common';
+import { Component, computed, DestroyRef, effect, ElementRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { CommonModule } from '@angular/common';
 import { ProfileService } from '../../services/profile.service';
 import { AppStore } from '../../app-store';
-import { map, switchMap } from 'rxjs';
+import { tap } from 'rxjs';
 import { baseUrl } from '../../core/constants';
-import { Observable } from 'rxjs';
 import { Router, RouterModule } from '@angular/router';
 import { HubClient } from '../../core/hub-client';
 import { MatToolbarModule } from '@angular/material/toolbar';
@@ -21,7 +21,6 @@ import { TranslateModule } from '@ngx-translate/core';
   standalone: true,
   imports: [
     CommonModule,
-    AsyncPipe,
     RouterModule,
     MatToolbarModule,
     MatSidenavModule,
@@ -39,34 +38,37 @@ export class MasterPageComponent {
   private readonly _appStore = inject(AppStore);
   private readonly _router = inject(Router);
   private readonly _baseUrl: string = inject(baseUrl as any);
+  private readonly _destroyRef = inject(DestroyRef);
+
+  public readonly profileName = computed(() => this._appStore.currentProfile().name);
+
+  constructor() {
+    effect(() => {
+      const profile = this._appStore.currentProfile();
+      if (profile?.avatarUrl) {
+        this._setCustomProperty('--background-image-url', `url(${this._baseUrl}${profile.avatarUrl})`);
+      }
+    });
+  }
 
   public ngOnInit() {
     this._profileService.current()
       .pipe(
-        map(x => this._appStore.currentProfile$.next(x)),
-        switchMap(x => this._appStore.currentProfile$),
-        map(x => {
-          this._setCustomProperty('--background-image-url', `url(${this._baseUrl}${x.avatarUrl})`);
-        })
+        takeUntilDestroyed(this._destroyRef),
+        tap(x => this._appStore.currentProfile.set(x))
       )
       .subscribe();
 
     this._hubClient.messages$
       .pipe(
-        map(x => {
-          this._appStore.currentProfile$.next(x.profile);
-          this._setCustomProperty('--background-image-url', `url(${this._baseUrl}${x.profile.avatarUrl})`);
-        })
+        takeUntilDestroyed(this._destroyRef),
+        tap(x => this._appStore.currentProfile.set(x.profile))
       )
       .subscribe();
   }
 
   protected _setCustomProperty(key: string, value: any) {
     this._elementRef.nativeElement.style.setProperty(key, value);
-  }
-
-  public get profileName$(): Observable<string> {
-    return this._appStore.currentProfile$.pipe(map(x => x.name));
   }
 
   public onProfileNameClick() {

--- a/frontend/projects/commitments-app/src/app/components/quill-text-editor/quill-text-editor.component.ts
+++ b/frontend/projects/commitments-app/src/app/components/quill-text-editor/quill-text-editor.component.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Component, ElementRef, forwardRef, Input, inject } from '@angular/core';
+import { Component, ElementRef, forwardRef, inject, input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
@@ -49,7 +49,7 @@ export class QuillTextEditorComponent implements ControlValueAccessor {
   public ngAfterViewInit() {
     this._quill = new Quill(this.nativeElement, {
       theme: 'bubble',
-      placeholder: this.editorPlaceholder
+      placeholder: this.editorPlaceholder()
     });
 
     this._quill.on('text-change', this.onTextChanged);
@@ -59,7 +59,7 @@ export class QuillTextEditorComponent implements ControlValueAccessor {
     this.onChangeCallback(this.qlEditorNativeElement.innerHTML);
   }
 
-  @Input() public editorPlaceholder: string;
+  public readonly editorPlaceholder = input<string>('');
 
   public get nativeElement(): HTMLElement {
     return this._elementRef.nativeElement.querySelector('.editor') as HTMLElement;

--- a/frontend/projects/commitments-app/src/app/components/star-cell/star-cell.component.ts
+++ b/frontend/projects/commitments-app/src/app/components/star-cell/star-cell.component.ts
@@ -3,7 +3,6 @@
 
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Subject } from 'rxjs';
 import { ICellRendererAngularComp } from 'ag-grid-angular';
 import { IAfterGuiAttachedParams, ICellRendererParams } from 'ag-grid-community';
 import { MatIconModule } from '@angular/material/icon';
@@ -23,10 +22,4 @@ export class StarCellComponent implements ICellRendererAngularComp {
   agInit(_params: ICellRendererParams): void {}
 
   afterGuiAttached?(_params?: IAfterGuiAttachedParams): void {}
-
-  public onDestroy: Subject<void> = new Subject<void>();
-
-  ngOnDestroy() {
-    this.onDestroy.next();
-  }
 }

--- a/frontend/projects/commitments-app/src/app/core/store.ts
+++ b/frontend/projects/commitments-app/src/app/core/store.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Injectable, inject } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
+import { Injectable, inject, signal, WritableSignal } from '@angular/core';
 import { map } from 'rxjs/operators';
 
 import { HubClient } from './hub-client';
@@ -18,23 +17,20 @@ export interface TagRemovedPayload { tagId: string; }
 export class Store {
   private readonly _hubClient: HubClient;
 
-  public note$: BehaviorSubject<Note> = new BehaviorSubject(<Note>{});
-  public notes$: BehaviorSubject<Array<Note>> = new BehaviorSubject([]);
-  public tags$: BehaviorSubject<Array<Tag>> = new BehaviorSubject([]);
+  public readonly note: WritableSignal<Note> = signal(<Note>{});
+  public readonly notes: WritableSignal<Array<Note>> = signal([]);
+  public readonly tags: WritableSignal<Array<Tag>> = signal([]);
 
   constructor(hubClient: HubClient = inject(HubClient)) {
     this._hubClient = hubClient;
   }
 
   public handleTagSaved(payload: { tag: Tag }) {
-    this.tags$.next([...this.tags$.value, payload.tag]);
+    this.tags.update(tags => [...tags, payload.tag]);
   }
 
   public handleTagRemoved(payload: { tagId: number }) {
-    const tags = this.tags$.value;
-    const deletedTagIndex = tags.findIndex(x => x.tagId == payload.tagId);
-    tags.splice(deletedTagIndex, 1);
-    this.tags$.next([...tags]);
+    this.tags.update(tags => tags.filter(x => x.tagId != payload.tagId));
   }
 
   public get savedNotes$() {

--- a/frontend/projects/commitments-app/src/app/pages/activities/activities-page/activities-page.component.html
+++ b/frontend/projects/commitments-app/src/app/pages/activities/activities-page/activities-page.component.html
@@ -5,7 +5,7 @@
 <section class="page-content-container">
   <ag-grid-angular class="ag-theme-material"
                    [columnDefs]="columnDefs"
-                   [rowData]="activities$ | async"
+                   [rowData]="activities()"
                    [pagination]="true"
                    [paginationPageSize]="5"
                    [localeText]="localeText"

--- a/frontend/projects/commitments-app/src/app/pages/activities/activities-page/activities-page.component.ts
+++ b/frontend/projects/commitments-app/src/app/pages/activities/activities-page/activities-page.component.ts
@@ -1,15 +1,15 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Component, inject } from '@angular/core';
+import { Component, DestroyRef, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { AgGridModule } from 'ag-grid-angular';
 import { Router } from '@angular/router';
-import { BehaviorSubject, Subject } from 'rxjs';
-import { map, takeUntil } from 'rxjs';
+import { tap } from 'rxjs';
 import { ColDef, GridApi } from 'ag-grid-community';
 import { ActivityService } from '../../../services/activity.service';
 import { Activity } from '../../../models/activity';
@@ -37,55 +37,51 @@ export class ActivitiesPageComponent {
   private readonly _activityService = inject(ActivityService);
   private readonly _editActityDialog = inject(EditActivityDialogService);
   private readonly _router = inject(Router);
+  private readonly _destroyRef = inject(DestroyRef);
+
+  public readonly activities = signal<Array<Activity>>([]);
+
+  public localeText: any = {};
 
   ngOnInit() {
     this._activityService.get()
-      .pipe(map(x => this.activities$.next(x)))
+      .pipe(takeUntilDestroyed(this._destroyRef), tap(x => this.activities.set(x)))
       .subscribe();
   }
 
-  public onDestroy: Subject<void> = new Subject<void>();
-
-  public activities$: BehaviorSubject<Array<Activity>> = new BehaviorSubject([]);
-
-  ngOnDestroy() {
-    this.onDestroy.next();
-  }
-
   public handleRemoveClick($event) {
-    const activities: Array<Activity> = [...this.activities$.value];
-    const index = activities.findIndex(x => x.activityId == $event.data.activityId);
-    activities.splice(index, 1);
-    this.activities$.next(activities);
+    this.activities.update(activities => activities.filter(x => x.activityId != $event.data.activityId));
 
     this._activityService.remove({ activity: $event.data })
-      .pipe(takeUntil(this.onDestroy))
+      .pipe(takeUntilDestroyed(this._destroyRef))
       .subscribe();
   }
 
   public handleEditClick($event) {
     this._editActityDialog.create({ activityId: $event.data.activityId })
-      .pipe(takeUntil(this.onDestroy), map((x) => this.addOrUpdate(x)))
+      .pipe(takeUntilDestroyed(this._destroyRef), tap(x => this.addOrUpdate(x)))
       .subscribe();
   }
 
   public handleFABButtonClick() {
     this._editActityDialog.create()
-      .pipe(takeUntil(this.onDestroy), map((x) => this.addOrUpdate(x)))
+      .pipe(takeUntilDestroyed(this._destroyRef), tap(x => this.addOrUpdate(x)))
       .subscribe();
   }
 
   public addOrUpdate(activity: Activity) {
     if (!activity) return;
 
-    const activities = [...this.activities$.value];
-    const i = activities.findIndex((t) => t.activityId == activity.activityId);
-    if (i < 0) {
-      activities.push(activity);
-    } else {
-      activities[i] = activity;
-    }
-    this.activities$.next(activities);
+    this.activities.update(activities => {
+      const next = [...activities];
+      const i = next.findIndex(t => t.activityId == activity.activityId);
+      if (i < 0) {
+        next.push(activity);
+      } else {
+        next[i] = activity;
+      }
+      return next;
+    });
   }
 
   public columnDefs: Array<ColDef> = [

--- a/frontend/projects/commitments-app/src/app/pages/behaviour-types/behaviour-types-page/behaviour-types-page.component.html
+++ b/frontend/projects/commitments-app/src/app/pages/behaviour-types/behaviour-types-page/behaviour-types-page.component.html
@@ -5,7 +5,7 @@
 <section class="page-content-container">
   <ag-grid-angular class="ag-theme-material"
                    [columnDefs]="columnDefs"
-                   [rowData]="behaviourTypes$ | async"
+                   [rowData]="behaviourTypes()"
                    [pagination]="true"
                    [paginationPageSize]="5"
                    [localeText]="localeText"

--- a/frontend/projects/commitments-app/src/app/pages/behaviour-types/behaviour-types-page/behaviour-types-page.component.ts
+++ b/frontend/projects/commitments-app/src/app/pages/behaviour-types/behaviour-types-page/behaviour-types-page.component.ts
@@ -1,15 +1,15 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Component, inject } from '@angular/core';
+import { Component, DestroyRef, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { AgGridModule } from 'ag-grid-angular';
 import { Router } from '@angular/router';
-import { BehaviorSubject, Subject } from 'rxjs';
-import { map, takeUntil } from 'rxjs';
+import { tap } from 'rxjs';
 import { ColDef, GridApi } from 'ag-grid-community';
 import { BehaviourTypeService } from '../../../services/behaviour-type.service';
 import { BehaviourType } from '../../../models/behaviour-type';
@@ -37,29 +37,23 @@ export class BehaviourTypesPageComponent {
   private readonly _behaviourTypeService = inject(BehaviourTypeService);
   private readonly _editBehaviourTypeDialog = inject(EditBehaviourTypeDialogService);
   private readonly _router = inject(Router);
+  private readonly _destroyRef = inject(DestroyRef);
+
+  public readonly behaviourTypes = signal<Array<BehaviourType>>([]);
+
+  public localeText: any = {};
 
   ngOnInit() {
     this._behaviourTypeService.get()
-      .pipe(map(x => this.behaviourTypes$.next(x)))
+      .pipe(takeUntilDestroyed(this._destroyRef), tap(x => this.behaviourTypes.set(x)))
       .subscribe();
   }
 
-  public onDestroy: Subject<void> = new Subject<void>();
-
-  public behaviourTypes$: BehaviorSubject<Array<BehaviourType>> = new BehaviorSubject([]);
-
-  ngOnDestroy() {
-    this.onDestroy.next();
-  }
-
   public handleRemoveClick($event) {
-    const behaviourTypes: Array<BehaviourType> = [...this.behaviourTypes$.value];
-    const index = behaviourTypes.findIndex(x => x.behaviourTypeId == $event.data.behaviourTypeId);
-    behaviourTypes.splice(index, 1);
-    this.behaviourTypes$.next(behaviourTypes);
+    this.behaviourTypes.update(types => types.filter(x => x.behaviourTypeId != $event.data.behaviourTypeId));
 
     this._behaviourTypeService.remove({ behaviourType: $event.data })
-      .pipe(takeUntil(this.onDestroy))
+      .pipe(takeUntilDestroyed(this._destroyRef))
       .subscribe();
   }
 
@@ -69,21 +63,23 @@ export class BehaviourTypesPageComponent {
 
   public handleFABButtonClick() {
     this._editBehaviourTypeDialog.create()
-      .pipe(takeUntil(this.onDestroy), map((x) => this.addOrUpdate(x)))
+      .pipe(takeUntilDestroyed(this._destroyRef), tap(x => this.addOrUpdate(x)))
       .subscribe();
   }
 
   public addOrUpdate(behaviourType: BehaviourType) {
     if (!behaviourType) return;
 
-    const behaviourTypes = [...this.behaviourTypes$.value];
-    const i = behaviourTypes.findIndex((t) => t.behaviourTypeId == behaviourType.behaviourTypeId);
-    if (i < 0) {
-      behaviourTypes.push(behaviourType);
-    } else {
-      behaviourTypes[i] = behaviourType;
-    }
-    this.behaviourTypes$.next(behaviourTypes);
+    this.behaviourTypes.update(types => {
+      const next = [...types];
+      const i = next.findIndex(t => t.behaviourTypeId == behaviourType.behaviourTypeId);
+      if (i < 0) {
+        next.push(behaviourType);
+      } else {
+        next[i] = behaviourType;
+      }
+      return next;
+    });
   }
 
   public columnDefs: Array<ColDef> = [

--- a/frontend/projects/commitments-app/src/app/pages/behaviours/behaviours-page/behaviours-page.component.html
+++ b/frontend/projects/commitments-app/src/app/pages/behaviours/behaviours-page/behaviours-page.component.html
@@ -5,7 +5,7 @@
 <section class="page-content-container">
   <ag-grid-angular class="ag-theme-material"
                    [columnDefs]="columnDefs"
-                   [rowData]="behaviours$ | async"
+                   [rowData]="behaviours()"
                    [pagination]="true"
                    [paginationPageSize]="5"
                    [localeText]="localeText"

--- a/frontend/projects/commitments-app/src/app/pages/behaviours/behaviours-page/behaviours-page.component.ts
+++ b/frontend/projects/commitments-app/src/app/pages/behaviours/behaviours-page/behaviours-page.component.ts
@@ -1,15 +1,15 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Component, inject } from '@angular/core';
+import { Component, DestroyRef, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { AgGridModule } from 'ag-grid-angular';
 import { Router } from '@angular/router';
-import { BehaviorSubject, Observable, Subject } from 'rxjs';
-import { map, takeUntil } from 'rxjs';
+import { tap } from 'rxjs';
 import { ColDef, GridApi } from 'ag-grid-community';
 import { BehaviourService } from '../../../services/behaviour.service';
 import { Behaviour } from '../../../models/behaviour';
@@ -40,59 +40,53 @@ export class BehavioursPageComponent {
   private readonly _behaviourTypeService = inject(BehaviourTypeService);
   private readonly _editBehaviourDialog = inject(EditBehaviourDialogService);
   private readonly _router = inject(Router);
+  private readonly _destroyRef = inject(DestroyRef);
+
+  public readonly behaviour = signal<Behaviour>(<Behaviour>{});
+  public readonly behaviours = signal<Array<Behaviour>>([]);
+  public readonly behaviourTypes = signal<Array<BehaviourType>>([]);
+
+  public localeText: any = {};
 
   ngOnInit() {
     this._behaviourService.get()
-      .pipe(map(x => this.behaviours$.next(x)))
+      .pipe(takeUntilDestroyed(this._destroyRef), tap(x => this.behaviours.set(x)))
       .subscribe();
   }
-
-  public behaviourTypes$: Observable<Array<BehaviourType>>;
-
-  public onDestroy: Subject<void> = new Subject<void>();
-
-  public behaviour$: BehaviorSubject<Behaviour> = new BehaviorSubject(<Behaviour>{});
-
-  public behaviours$: BehaviorSubject<Array<Behaviour>> = new BehaviorSubject([]);
 
   public handleFABButtonClick() {
-    this._editBehaviourDialog.create({ behaviourId: this.behaviour$.value.behaviourId })
-      .pipe(map(toDo => this.addOrUpdate(toDo)), takeUntil(this.onDestroy))
+    this._editBehaviourDialog.create({ behaviourId: this.behaviour().behaviourId })
+      .pipe(takeUntilDestroyed(this._destroyRef), tap(b => this.addOrUpdate(b)))
       .subscribe();
-  }
-
-  ngOnDestroy() {
-    this.onDestroy.next();
   }
 
   public handleRemoveClick($event) {
-    const behaviours: Array<Behaviour> = [...this.behaviours$.value];
-    const index = behaviours.findIndex(x => x.behaviourId == $event.data.behaviourId);
-    behaviours.splice(index, 1);
-    this.behaviours$.next(behaviours);
+    this.behaviours.update(bs => bs.filter(x => x.behaviourId != $event.data.behaviourId));
 
     this._behaviourService.remove({ behaviour: $event.data })
-      .pipe(takeUntil(this.onDestroy))
+      .pipe(takeUntilDestroyed(this._destroyRef))
       .subscribe();
   }
 
   public handleEditClick($event) {
     this._editBehaviourDialog.create({ behaviourId: $event.data.behaviourId })
-      .pipe(map(toDo => this.addOrUpdate(toDo)), takeUntil(this.onDestroy))
+      .pipe(takeUntilDestroyed(this._destroyRef), tap(b => this.addOrUpdate(b)))
       .subscribe();
   }
 
   public addOrUpdate(behaviour: Behaviour) {
     if (!behaviour) return;
 
-    const behaviours = [...this.behaviours$.value];
-    const i = behaviours.findIndex((t) => t.behaviourId == behaviour.behaviourId);
-    if (i < 0) {
-      behaviours.push(behaviour);
-    } else {
-      behaviours[i] = behaviour;
-    }
-    this.behaviours$.next(behaviours);
+    this.behaviours.update(bs => {
+      const next = [...bs];
+      const i = next.findIndex(t => t.behaviourId == behaviour.behaviourId);
+      if (i < 0) {
+        next.push(behaviour);
+      } else {
+        next[i] = behaviour;
+      }
+      return next;
+    });
   }
 
   public columnDefs: Array<ColDef> = [

--- a/frontend/projects/commitments-app/src/app/pages/card-layouts/card-layouts-page/card-layouts-page.component.html
+++ b/frontend/projects/commitments-app/src/app/pages/card-layouts/card-layouts-page/card-layouts-page.component.html
@@ -5,7 +5,7 @@
 <section class="page-content-container">
   <ag-grid-angular class="ag-theme-material"
                    [columnDefs]="columnDefs"
-                   [rowData]="cardLayouts$ | async"
+                   [rowData]="cardLayouts()"
                    [pagination]="true"
                    [paginationPageSize]="5"
                    [localeText]="localeText"

--- a/frontend/projects/commitments-app/src/app/pages/card-layouts/card-layouts-page/card-layouts-page.component.ts
+++ b/frontend/projects/commitments-app/src/app/pages/card-layouts/card-layouts-page/card-layouts-page.component.ts
@@ -1,15 +1,15 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Component, inject } from '@angular/core';
+import { Component, DestroyRef, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { AgGridModule } from 'ag-grid-angular';
 import { Router } from '@angular/router';
-import { BehaviorSubject, Subject } from 'rxjs';
-import { map, takeUntil } from 'rxjs';
+import { tap } from 'rxjs';
 import { ColDef, GridApi } from 'ag-grid-community';
 import { CardLayoutService } from '../../../services/card-layout.service';
 import { CardLayout } from '../../../models/card-layout';
@@ -37,29 +37,23 @@ export class CardLayoutsPageComponent {
   private readonly _cardLayoutService = inject(CardLayoutService);
   private readonly _editCardLayoutDialog = inject(EditCardLayoutDialogService);
   private readonly _router = inject(Router);
+  private readonly _destroyRef = inject(DestroyRef);
+
+  public readonly cardLayouts = signal<Array<CardLayout>>([]);
+
+  public localeText: any = {};
 
   ngOnInit() {
     this._cardLayoutService.get()
-      .pipe(map(x => this.cardLayouts$.next(x)))
+      .pipe(takeUntilDestroyed(this._destroyRef), tap(x => this.cardLayouts.set(x)))
       .subscribe();
   }
 
-  public onDestroy: Subject<void> = new Subject<void>();
-
-  public cardLayouts$: BehaviorSubject<Array<CardLayout>> = new BehaviorSubject([]);
-
-  ngOnDestroy() {
-    this.onDestroy.next();
-  }
-
   public handleRemoveClick($event) {
-    const cardLayouts: Array<CardLayout> = [...this.cardLayouts$.value];
-    const index = cardLayouts.findIndex(x => x.cardLayoutId == $event.data.cardLayoutId);
-    cardLayouts.splice(index, 1);
-    this.cardLayouts$.next(cardLayouts);
+    this.cardLayouts.update(layouts => layouts.filter(x => x.cardLayoutId != $event.data.cardLayoutId));
 
     this._cardLayoutService.remove({ cardLayout: $event.data })
-      .pipe(takeUntil(this.onDestroy))
+      .pipe(takeUntilDestroyed(this._destroyRef))
       .subscribe();
   }
 
@@ -70,14 +64,16 @@ export class CardLayoutsPageComponent {
   public addOrUpdate(cardLayout: CardLayout) {
     if (!cardLayout) return;
 
-    const cardLayouts = [...this.cardLayouts$.value];
-    const i = cardLayouts.findIndex((t) => t.cardLayoutId == cardLayout.cardLayoutId);
-    if (i < 0) {
-      cardLayouts.push(cardLayout);
-    } else {
-      cardLayouts[i] = cardLayout;
-    }
-    this.cardLayouts$.next(cardLayouts);
+    this.cardLayouts.update(layouts => {
+      const next = [...layouts];
+      const i = next.findIndex(t => t.cardLayoutId == cardLayout.cardLayoutId);
+      if (i < 0) {
+        next.push(cardLayout);
+      } else {
+        next[i] = cardLayout;
+      }
+      return next;
+    });
   }
 
   public columnDefs: Array<ColDef> = [
@@ -101,7 +97,7 @@ export class CardLayoutsPageComponent {
 
   public handleFABButtonClick() {
     this._editCardLayoutDialog.create()
-      .pipe(takeUntil(this.onDestroy), map(x => this.addOrUpdate(x)))
+      .pipe(takeUntilDestroyed(this._destroyRef), tap(x => this.addOrUpdate(x)))
       .subscribe();
   }
 }

--- a/frontend/projects/commitments-app/src/app/pages/cards/cards-page/cards-page.component.html
+++ b/frontend/projects/commitments-app/src/app/pages/cards/cards-page/cards-page.component.html
@@ -5,7 +5,7 @@
 <section class="page-content-container">
   <ag-grid-angular class="ag-theme-material"
                    [columnDefs]="columnDefs"
-                   [rowData]="cards$ | async"
+                   [rowData]="cards()"
                    [pagination]="true"
                    [paginationPageSize]="5"
                    [localeText]="localeText"

--- a/frontend/projects/commitments-app/src/app/pages/cards/cards-page/cards-page.component.ts
+++ b/frontend/projects/commitments-app/src/app/pages/cards/cards-page/cards-page.component.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Component, inject } from '@angular/core';
+import { Component, DestroyRef, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { AgGridModule } from 'ag-grid-angular';
-import { BehaviorSubject, Subject } from 'rxjs';
-import { map, switchMap, takeUntil } from 'rxjs';
+import { tap } from 'rxjs';
 import { ColDef, GridApi } from 'ag-grid-community';
 import { CardService } from '../../../services/card.service';
 import { Card } from '../../../models/card';
@@ -34,13 +34,17 @@ import { PrimaryHeaderComponent } from '@commitments/ui';
 export class CardsPageComponent {
   private readonly _cardService = inject(CardService);
   private readonly _editCardDialog = inject(EditCardDialogService);
+  private readonly _destroyRef = inject(DestroyRef);
+
+  public readonly cards = signal<Card[]>([]);
+
+  public localeText: any = {};
 
   ngOnInit() {
     this._cardService.get()
       .pipe(
-        map(cards => this.cards$.next(cards)),
-        switchMap(() => this.cards$),
-        takeUntil(this.onDestroy)
+        takeUntilDestroyed(this._destroyRef),
+        tap(cards => this.cards.set(cards))
       )
       .subscribe();
   }
@@ -48,8 +52,8 @@ export class CardsPageComponent {
   public handleFABButtonClick() {
     this._editCardDialog.create()
       .pipe(
-        map(x => this.addOrUpdate(x)),
-        takeUntil(this.onDestroy)
+        takeUntilDestroyed(this._destroyRef),
+        tap(x => this.addOrUpdate(x))
       )
       .subscribe();
   }
@@ -72,46 +76,35 @@ export class CardsPageComponent {
     this._gridApi.sizeColumnsToFit();
   }
 
-  public cards$: BehaviorSubject<Card[]> = new BehaviorSubject([]);
-
   public handleEditClick($event) {
-    const overlayRefWrapper = this._editCardDialog
+    this._editCardDialog
       .create({ cardId: $event.data.cardId })
-      .pipe(map(card => this.addOrUpdate(card)), takeUntil(this.onDestroy))
+      .pipe(takeUntilDestroyed(this._destroyRef), tap(card => this.addOrUpdate(card)))
       .subscribe();
   }
 
   public handleRemove($event) {
     const card = $event.data;
 
-    const cards: Array<Card> = [...this.cards$.value];
-    const index = cards.findIndex(x => x.cardId == $event.data.cardId);
-    cards.splice(index, 1);
-    this.cards$.next(cards);
+    this.cards.update(cards => cards.filter(x => x.cardId != card.cardId));
 
-    this._cardService.remove({ card: card })
-      .pipe(takeUntil(this.onDestroy))
+    this._cardService.remove({ card })
+      .pipe(takeUntilDestroyed(this._destroyRef))
       .subscribe();
   }
 
   public addOrUpdate(card: Card) {
     if (!card) return;
 
-    const cards = [...this.cards$.value];
-    const i = cards.findIndex((t) => t.cardId == card.cardId);
-
-    if (i < 0) {
-      cards.push(card);
-    } else {
-      cards[i] = card;
-    }
-
-    this.cards$.next(cards);
-  }
-
-  public onDestroy: Subject<void> = new Subject<void>();
-
-  ngOnDestroy() {
-    this.onDestroy.next();
+    this.cards.update(cards => {
+      const next = [...cards];
+      const i = next.findIndex(t => t.cardId == card.cardId);
+      if (i < 0) {
+        next.push(card);
+      } else {
+        next[i] = card;
+      }
+      return next;
+    });
   }
 }

--- a/frontend/projects/commitments-app/src/app/pages/commitments/commitments-page/commitments-page.component.html
+++ b/frontend/projects/commitments-app/src/app/pages/commitments/commitments-page/commitments-page.component.html
@@ -5,7 +5,7 @@
 <section class="page-content-container">
   <ag-grid-angular class="ag-theme-material"
                    [columnDefs]="columnDefs"
-                   [rowData]="commitments$ | async"
+                   [rowData]="commitments()"
                    [pagination]="true"
                    [paginationPageSize]="5"
                    [localeText]="localeText"

--- a/frontend/projects/commitments-app/src/app/pages/commitments/commitments-page/commitments-page.component.ts
+++ b/frontend/projects/commitments-app/src/app/pages/commitments/commitments-page/commitments-page.component.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Component, inject } from '@angular/core';
+import { Component, DestroyRef, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { AgGridModule } from 'ag-grid-angular';
-import { BehaviorSubject, Subject } from 'rxjs';
-import { map, takeUntil } from 'rxjs';
+import { tap } from 'rxjs';
 import { ColDef, GridApi } from 'ag-grid-community';
 import { CommitmentService } from '../../../services/commitment.service';
 import { Commitment } from '../../../models/commitment';
@@ -35,19 +35,16 @@ import { PrimaryHeaderComponent } from '@commitments/ui';
 export class CommitmentsPageComponent {
   private readonly _commitmentService = inject(CommitmentService);
   private readonly _editCommitmentDialog = inject(EditCommitmentDialogService);
+  private readonly _destroyRef = inject(DestroyRef);
+
+  public readonly commitments = signal<Commitment[]>([]);
+
+  public localeText: any = {};
 
   ngOnInit() {
     this._commitmentService.getPersonal()
-      .pipe(takeUntil(this.onDestroy), map(x => this.commitments$.next(x)))
+      .pipe(takeUntilDestroyed(this._destroyRef), tap(x => this.commitments.set(x)))
       .subscribe();
-  }
-
-  public commitments$: BehaviorSubject<Commitment[]> = new BehaviorSubject([]);
-
-  public onDestroy: Subject<void> = new Subject<void>();
-
-  ngOnDestroy() {
-    this.onDestroy.next();
   }
 
   public columnDefs: Array<ColDef> = [
@@ -72,41 +69,38 @@ export class CommitmentsPageComponent {
 
   public handleFABButtonClick() {
     this._editCommitmentDialog.create()
-      .pipe(takeUntil(this.onDestroy))
+      .pipe(takeUntilDestroyed(this._destroyRef))
       .subscribe();
   }
 
   public handleEditClick($event) {
     this._editCommitmentDialog.create({ commitmentId: $event.data.commitmentId })
-      .pipe(map(commitment => this.addOrUpdate(commitment)), takeUntil(this.onDestroy))
+      .pipe(takeUntilDestroyed(this._destroyRef), tap(commitment => this.addOrUpdate(commitment)))
       .subscribe();
   }
 
   public handleRemoveClick($event) {
     const commitment = $event.data;
 
-    const commitments: Array<Commitment> = [...this.commitments$.value];
-    const index = commitments.findIndex(x => x.commitmentId == $event.data.commitmentId);
-    commitments.splice(index, 1);
-    this.commitments$.next(commitments);
+    this.commitments.update(commitments => commitments.filter(x => x.commitmentId != commitment.commitmentId));
 
     this._commitmentService.remove({ commitment })
-      .pipe(takeUntil(this.onDestroy))
+      .pipe(takeUntilDestroyed(this._destroyRef))
       .subscribe();
   }
 
   public addOrUpdate(commitment: Commitment) {
     if (!commitment) return;
 
-    const commitments = [...this.commitments$.value];
-    const i = commitments.findIndex((t) => t.commitmentId == commitment.commitmentId);
-
-    if (i < 0) {
-      commitments.push(commitment);
-    } else {
-      commitments[i] = commitment;
-    }
-
-    this.commitments$.next(commitments);
+    this.commitments.update(commitments => {
+      const next = [...commitments];
+      const i = next.findIndex(t => t.commitmentId == commitment.commitmentId);
+      if (i < 0) {
+        next.push(commitment);
+      } else {
+        next[i] = commitment;
+      }
+      return next;
+    });
   }
 }

--- a/frontend/projects/commitments-app/src/app/pages/edit-frequency/edit-frequency-page/edit-frequency-page.component.ts
+++ b/frontend/projects/commitments-app/src/app/pages/edit-frequency/edit-frequency-page/edit-frequency-page.component.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Component, inject } from '@angular/core';
+import { Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
-import { Subject, takeUntil } from 'rxjs';
 import { EditFrequencyDialogService } from '../../../services/edit-frequency-dialog.service';
 import { PrimaryHeaderComponent } from '@commitments/ui';
 
@@ -20,8 +20,7 @@ export class EditFrequencyPageComponent {
   private readonly _dialog = inject(EditFrequencyDialogService);
   private readonly _route = inject(ActivatedRoute);
   private readonly _router = inject(Router);
-
-  public onDestroy: Subject<void> = new Subject<void>();
+  private readonly _destroyRef = inject(DestroyRef);
 
   ngOnInit() {
     const frequencyIdParam = this._route.snapshot.paramMap.get('frequencyId');
@@ -29,11 +28,7 @@ export class EditFrequencyPageComponent {
     const frequencyId = frequencyIdParam ? Number(frequencyIdParam) : undefined;
 
     this._dialog.create({ frequencyId })
-      .pipe(takeUntil(this.onDestroy))
+      .pipe(takeUntilDestroyed(this._destroyRef))
       .subscribe(() => this._router.navigateByUrl(returnTo));
-  }
-
-  ngOnDestroy() {
-    this.onDestroy.next();
   }
 }

--- a/frontend/projects/commitments-app/src/app/pages/edit-note/edit-note-page/edit-note-page.component.html
+++ b/frontend/projects/commitments-app/src/app/pages/edit-note/edit-note-page/edit-note-page.component.html
@@ -1,8 +1,8 @@
-<app-primary-header *ngIf="!(note$ | async).noteId">
+<app-primary-header *ngIf="!hasNoteId()">
   {{ "Create Note" | translate }}
 </app-primary-header>
 
-<app-primary-header *ngIf="(note$ | async).noteId">
+<app-primary-header *ngIf="hasNoteId()">
   {{ "Edit Note" | translate }}
 </app-primary-header>
 

--- a/frontend/projects/commitments-app/src/app/pages/edit-note/edit-note-page/edit-note-page.component.ts
+++ b/frontend/projects/commitments-app/src/app/pages/edit-note/edit-note-page/edit-note-page.component.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Component, ElementRef, inject } from '@angular/core';
+import { Component, computed, DestroyRef, ElementRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormGroup, FormControl, Validators } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
@@ -9,11 +10,9 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { ActivatedRoute, Router } from '@angular/router';
-import { BehaviorSubject, Observable, Subject } from 'rxjs';
-import { takeUntil, tap } from 'rxjs';
+import { tap } from 'rxjs';
 import { NotesService } from '../../../services/notes.service';
 import { Note } from '../../../models/note';
-import { Tag } from '../../../models/tag';
 import { Store } from '../../../core/store';
 import { LanguageService } from '../../../core/language.service';
 import { LocalStorageService } from '../../../core/local-storage.service';
@@ -46,15 +45,16 @@ export class EditNotePageComponent {
   private readonly _notesService = inject(NotesService);
   private readonly _router = inject(Router);
   private readonly _store = inject(Store);
+  private readonly _destroyRef = inject(DestroyRef);
 
   selectedItems: any[];
   items: any[];
 
   public editorPlaceholder: string = 'Compose a note...';
 
-  public notes$: BehaviorSubject<Note> = new BehaviorSubject(<Note>{});
-
-  public onDestroy: Subject<void> = new Subject();
+  public readonly note = this._store.note;
+  public readonly tags = this._store.tags;
+  public readonly hasNoteId = computed(() => !!this.note().noteId);
 
   public quillEditorFormControl: FormControl = new FormControl('');
 
@@ -67,11 +67,12 @@ export class EditNotePageComponent {
   constructor() {
     this.editorPlaceholder = this._languageService.currentTranslations[this.editorPlaceholder];
 
-    this.selectedItems = this._store.note$.value.tags.map(x => x.name);
-    this.items = this._store.tags$.value;
+    const note = this._store.note();
+    this.selectedItems = note.tags.map(x => x.name);
+    this.items = this._store.tags();
 
-    this.form.controls['title'].setValue(this._store.note$.value.title);
-    this.form.controls['body'].setValue(this._store.note$.value.body);
+    this.form.controls['title'].setValue(note.title);
+    this.form.controls['body'].setValue(note.body);
   }
 
   canDeactivate() {
@@ -79,34 +80,27 @@ export class EditNotePageComponent {
   }
 
   ngAfterViewInit() {
+    const note = this._store.note();
     this.form.patchValue({
-      title: this.note$.value.title,
-      body: this.note$.value.body
+      title: note.title,
+      body: note.body
     });
-  }
-
-  public get tags$(): Observable<Array<Tag>> {
-    return this._store.tags$;
-  }
-
-  public get note$(): BehaviorSubject<Note> {
-    return this._store.note$;
   }
 
   public handleSaveClick() {
     const note = new Note();
     const tags = this.form.value.tags || [];
 
-    note.noteId = this._store.note$.value.noteId;
+    note.noteId = this._store.note().noteId;
     note.title = this.form.value.title;
     note.body = this.form.value.body;
-    note.tags = tags.map(x => this._store.tags$.value.find(t => t.name == x));
+    note.tags = tags.map(x => this._store.tags().find(t => t.name == x));
 
     this._notesService
       .save({
         note
       })
-      .pipe(takeUntil(this.onDestroy), tap(() => this._router.navigateByUrl('/notes')))
+      .pipe(takeUntilDestroyed(this._destroyRef), tap(() => this._router.navigateByUrl('/notes')))
       .subscribe();
   }
 
@@ -114,16 +108,12 @@ export class EditNotePageComponent {
     return this._activatedRoute.snapshot.params['slug'];
   }
 
-  ngOnDestroy() {
-    this.onDestroy.next();
-  }
-
   filterItems(itemName: string) {
     return this.items.filter(item => item.name.toLowerCase().indexOf(itemName.toLowerCase()) === 0);
   }
 
   handleChipClicked($event) {
-    const tag = this._store.tags$.value.find(x => x.name == $event.item);
+    const tag = this._store.tags().find(x => x.name == $event.item);
     this._router.navigate(['tags', tag.slug]);
   }
 }

--- a/frontend/projects/commitments-app/src/app/pages/frequencies/frequencies-page/frequencies-page.component.html
+++ b/frontend/projects/commitments-app/src/app/pages/frequencies/frequencies-page/frequencies-page.component.html
@@ -5,7 +5,7 @@
 <section class="page-content-container">
   <ag-grid-angular class="ag-theme-material"
                    [columnDefs]="columnDefs"
-                   [rowData]="frequencies$ | async"
+                   [rowData]="frequencies()"
                    [pagination]="true"
                    [paginationPageSize]="5"
                    [localeText]="localeText"

--- a/frontend/projects/commitments-app/src/app/pages/frequencies/frequencies-page/frequencies-page.component.ts
+++ b/frontend/projects/commitments-app/src/app/pages/frequencies/frequencies-page/frequencies-page.component.ts
@@ -1,15 +1,15 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Component, inject } from '@angular/core';
+import { Component, DestroyRef, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { AgGridModule } from 'ag-grid-angular';
 import { Router } from '@angular/router';
-import { BehaviorSubject, Subject } from 'rxjs';
-import { map, takeUntil } from 'rxjs';
+import { tap } from 'rxjs';
 import { ColDef, GridApi } from 'ag-grid-community';
 import { FrequencyService } from '../../../services/frequency.service';
 import { Frequency } from '../../../models/frequency';
@@ -37,29 +37,23 @@ export class FrequenciesPageComponent {
   private readonly _editFrequencyDialog = inject(EditFrequencyDialogService);
   private readonly _frequencyService = inject(FrequencyService);
   private readonly _router = inject(Router);
+  private readonly _destroyRef = inject(DestroyRef);
+
+  public readonly frequencies = signal<Array<Frequency>>([]);
+
+  public localeText: any = {};
 
   ngOnInit() {
     this._frequencyService.get()
-      .pipe(map(x => this.frequencies$.next(x)))
+      .pipe(takeUntilDestroyed(this._destroyRef), tap(x => this.frequencies.set(x)))
       .subscribe();
   }
 
-  public onDestroy: Subject<void> = new Subject<void>();
-
-  public frequencies$: BehaviorSubject<Array<Frequency>> = new BehaviorSubject([]);
-
-  ngOnDestroy() {
-    this.onDestroy.next();
-  }
-
   public handleRemoveClick($event) {
-    const frequencies: Array<Frequency> = [...this.frequencies$.value];
-    const index = frequencies.findIndex(x => x.frequencyId == $event.data.frequencyId);
-    frequencies.splice(index, 1);
-    this.frequencies$.next(frequencies);
+    this.frequencies.update(freqs => freqs.filter(x => x.frequencyId != $event.data.frequencyId));
 
     this._frequencyService.remove({ frequency: $event.data })
-      .pipe(takeUntil(this.onDestroy))
+      .pipe(takeUntilDestroyed(this._destroyRef))
       .subscribe();
   }
 
@@ -69,21 +63,23 @@ export class FrequenciesPageComponent {
 
   public handleFABButtonClick() {
     this._editFrequencyDialog.create()
-      .pipe(takeUntil(this.onDestroy), map(x => this.addOrUpdate(x)))
+      .pipe(takeUntilDestroyed(this._destroyRef), tap(x => this.addOrUpdate(x)))
       .subscribe();
   }
 
   public addOrUpdate(frequency: Frequency) {
     if (!frequency) return;
 
-    const frequencies = [...this.frequencies$.value];
-    const i = frequencies.findIndex((t) => t.frequencyId == frequency.frequencyId);
-    if (i < 0) {
-      frequencies.push(frequency);
-    } else {
-      frequencies[i] = frequency;
-    }
-    this.frequencies$.next(frequencies);
+    this.frequencies.update(freqs => {
+      const next = [...freqs];
+      const i = next.findIndex(t => t.frequencyId == frequency.frequencyId);
+      if (i < 0) {
+        next.push(frequency);
+      } else {
+        next[i] = frequency;
+      }
+      return next;
+    });
   }
 
   public columnDefs: Array<ColDef> = [

--- a/frontend/projects/commitments-app/src/app/pages/login/login-page/login-page.component.ts
+++ b/frontend/projects/commitments-app/src/app/pages/login/login-page/login-page.component.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Component, ElementRef, HostListener, inject } from '@angular/core';
+import { Component, DestroyRef, ElementRef, HostListener, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormGroup, FormControl, Validators } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
@@ -10,8 +11,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSnackBarRef, SimpleSnackBar } from '@angular/material/snack-bar';
-import { Subject } from 'rxjs';
-import { map, switchMap, takeUntil, tap } from 'rxjs';
+import { switchMap, tap } from 'rxjs';
 import { AuthService } from '../../../core/auth.service';
 import { LoginRedirectService } from '../../../core/redirect.service';
 import { ErrorService } from '../../../core/error.service';
@@ -41,12 +41,11 @@ export class LoginPageComponent {
   private readonly _loginRedirectService = inject(LoginRedirectService);
   private readonly _profileService = inject(ProfileService);
   private readonly _storage = inject(LocalStorageService);
+  private readonly _destroyRef = inject(DestroyRef);
 
   ngOnInit() {
     this._authService.logout();
   }
-
-  public onDestroy: Subject<void> = new Subject<void>();
 
   ngAfterContentInit() {
     this.usernameNativeElement?.focus();
@@ -79,7 +78,7 @@ export class LoginPageComponent {
         password: $event.value.password
       })
       .pipe(
-        takeUntil(this.onDestroy),
+        takeUntilDestroyed(this._destroyRef),
         switchMap(() => this._profileService.current()),
         tap(profile => this._storage.put({ name: currentProfileIdKey, value: profile.profileId }))
       )
@@ -93,11 +92,7 @@ export class LoginPageComponent {
     const message = errorResponse?.status === 401 ? 'Login Failed' : 'An error occurred. Try it again.';
     this._errorService
       .handle$(errorResponse, message)
-      .pipe(takeUntil(this.onDestroy), map(snackBarRef => (this._snackBarRef = snackBarRef)))
+      .pipe(takeUntilDestroyed(this._destroyRef), tap(snackBarRef => (this._snackBarRef = snackBarRef)))
       .subscribe();
-  }
-
-  ngOnDestroy() {
-    this.onDestroy.next();
   }
 }

--- a/frontend/projects/commitments-app/src/app/pages/my-profile/my-profile-page/my-profile-page.component.html
+++ b/frontend/projects/commitments-app/src/app/pages/my-profile/my-profile-page/my-profile-page.component.html
@@ -4,7 +4,7 @@
 
 <section class="page-content-container">
   <form novalidate autocomplete="off" spellcheck="false" [formGroup]="form">
-    <img src="{{ baseUrl }}{{ (profile$ | async)?.avatarUrl }}" />
+    <img src="{{ baseUrl }}{{ profile()?.avatarUrl }}" />
 
     <app-digital-asset-input-url [placeholder]="'Avatar Image Url'" formControlName="avatarUrl"></app-digital-asset-input-url>
 

--- a/frontend/projects/commitments-app/src/app/pages/my-profile/my-profile-page/my-profile-page.component.ts
+++ b/frontend/projects/commitments-app/src/app/pages/my-profile/my-profile-page/my-profile-page.component.ts
@@ -1,15 +1,15 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Component, Inject, inject } from '@angular/core';
+import { Component, DestroyRef, Inject, inject } from '@angular/core';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormGroup, FormControl } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
-import { Observable, Subject, forkJoin } from 'rxjs';
-import { takeUntil, tap } from 'rxjs';
+import { forkJoin, tap } from 'rxjs';
 import { ProfileService } from '../../../services/profile.service';
 import { Profile } from '../../../models/profile';
 import { baseUrl } from '../../../core/constants';
@@ -34,34 +34,26 @@ import { PrimaryHeaderComponent } from '@commitments/ui';
 })
 export class MyProfilePageComponent {
   private readonly _profileService = inject(ProfileService);
+  private readonly _destroyRef = inject(DestroyRef);
 
   @Inject(baseUrl) public baseUrl: string;
 
-  public ngOnInit() {
-    this.profile$ = this._profileService.current()
-      .pipe(
-        tap(x => this.form.patchValue({
-          name: x.name,
-          avatarUrl: x.avatarUrl
-        }))
-      );
-  }
+  public readonly profile = toSignal<Profile>(
+    this._profileService.current().pipe(
+      tap(x => this.form.patchValue({
+        name: x.name,
+        avatarUrl: x.avatarUrl
+      }))
+    )
+  );
 
   public handleSaveClick() {
     forkJoin([
       this._profileService.saveAvatarUrl({ avatarUrl: this.form.value.avatarUrl }),
       this._profileService.updateDisplayName({ displayName: this.form.value.name })
     ])
-      .pipe(takeUntil(this.onDestroy))
+      .pipe(takeUntilDestroyed(this._destroyRef))
       .subscribe();
-  }
-
-  public profile$: Observable<Profile>;
-
-  public onDestroy: Subject<void> = new Subject<void>();
-
-  ngOnDestroy() {
-    this.onDestroy.next();
   }
 
   public form: FormGroup = new FormGroup({

--- a/frontend/projects/commitments-app/src/app/pages/notes-by-tag/notes-by-tag-page/notes-by-tag-page.component.html
+++ b/frontend/projects/commitments-app/src/app/pages/notes-by-tag/notes-by-tag-page/notes-by-tag-page.component.html
@@ -1,9 +1,9 @@
 <app-primary-header>
-  {{ (tag$ | async)?.name }}
+  {{ tag()?.name }}
 </app-primary-header>
 
 <section class="notes-by-tag-content-container">
-  <mat-card *ngFor="let note of (tag$ | async)?.notes">    
+  <mat-card *ngFor="let note of tag()?.notes">
     <mat-card-title>{{ note.title}}</mat-card-title>    
     <mat-card-content [innerHTML]="note.body"></mat-card-content>
   </mat-card>

--- a/frontend/projects/commitments-app/src/app/pages/notes-by-tag/notes-by-tag-page/notes-by-tag-page.component.ts
+++ b/frontend/projects/commitments-app/src/app/pages/notes-by-tag/notes-by-tag-page/notes-by-tag-page.component.ts
@@ -2,11 +2,11 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 import { Component, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatCardModule } from '@angular/material/card';
 import { ActivatedRoute } from '@angular/router';
-import { Observable, Subject } from 'rxjs';
 import { map } from 'rxjs';
 import { TagsService } from '../../../services/tags.service';
 import { Tag } from '../../../models/tag';
@@ -28,19 +28,11 @@ export class NotesByTagPageComponent {
   private readonly _activatedRoute = inject(ActivatedRoute);
   private readonly _tagsService = inject(TagsService);
 
-  ngOnInit() {
-    this.tag$ = this._tagsService.getBySlug({ slug: this.slug }).pipe(map(x => x.tag));
-  }
-
-  public tag$: Observable<Tag>;
-
-  public onDestroy: Subject<void> = new Subject<void>();
+  public readonly tag = toSignal<Tag>(
+    this._tagsService.getBySlug({ slug: this.slug }).pipe(map(x => x.tag))
+  );
 
   public get slug() {
     return this._activatedRoute.snapshot.params['slug'];
-  }
-
-  ngOnDestroy() {
-    this.onDestroy.next();
   }
 }

--- a/frontend/projects/commitments-app/src/app/pages/notes/notes-page/notes-page.component.html
+++ b/frontend/projects/commitments-app/src/app/pages/notes/notes-page/notes-page.component.html
@@ -5,7 +5,7 @@
 <section class="page-content-container">
   <ag-grid-angular class="ag-theme-material"
                    [columnDefs]="columnDefs"
-                   [rowData]="notes$ | async"
+                   [rowData]="notes()"
                    [pagination]="true"
                    [paginationPageSize]="5"
                    [localeText]="localeText"

--- a/frontend/projects/commitments-app/src/app/pages/notes/notes-page/notes-page.component.ts
+++ b/frontend/projects/commitments-app/src/app/pages/notes/notes-page/notes-page.component.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Component, inject } from '@angular/core';
+import { Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { AgGridModule } from 'ag-grid-angular';
 import { Router } from '@angular/router';
-import { Observable, Subject } from 'rxjs';
-import { map, takeUntil, tap } from 'rxjs';
+import { tap } from 'rxjs';
 import { ColDef } from 'ag-grid-community';
 import { NotesService } from '../../../services/notes.service';
 import { Note } from '../../../models/note';
@@ -32,20 +32,25 @@ export class NotesPageComponent {
   private readonly _store = inject(Store);
   private readonly _router = inject(Router);
   private readonly _translateService = inject(TranslateService);
+  private readonly _destroyRef = inject(DestroyRef);
 
-  public onDestroy: Subject<void> = new Subject<void>();
+  public readonly notes = this._store.notes;
 
   public localeText: any = {};
 
   ngOnInit() {
     this._notesService
       .get()
-      .pipe(map(x => this._store.notes$.next(x.notes)))
+      .pipe(
+        takeUntilDestroyed(this._destroyRef),
+        tap(x => this._store.notes.set(x.notes))
+      )
       .subscribe();
 
     this._translateService
       .get(['Title', 'Page', 'of', 'to'])
       .pipe(
+        takeUntilDestroyed(this._destroyRef),
         tap(translations => {
           this.localeText = translations;
           this.columnDefs = [
@@ -66,17 +71,12 @@ export class NotesPageComponent {
   }
 
   public handleDelete($event) {
-    const notes = this._store.notes$.value;
-    const deletedNoteIndex = notes.findIndex(x => x.noteId == $event.data.noteId);
-
-    notes.splice(deletedNoteIndex, 1);
-
     this._notesService
       .remove({ note: <Note>$event.data })
       .pipe(
-        takeUntil(this.onDestroy),
-        tap(x => {
-          this._store.notes$.next([...notes]);
+        takeUntilDestroyed(this._destroyRef),
+        tap(() => {
+          this._store.notes.update(notes => notes.filter(x => x.noteId != $event.data.noteId));
         })
       )
       .subscribe();
@@ -94,13 +94,5 @@ export class NotesPageComponent {
 
   public onGridReady($event) {
     $event.api.sizeColumnsToFit();
-  }
-
-  public get notes$(): Observable<Array<Note>> {
-    return this._store.notes$;
-  }
-
-  ngOnDestroy() {
-    this.onDestroy.next();
   }
 }

--- a/frontend/projects/commitments-app/src/app/pages/profiles/profiles-page/profiles-page.component.html
+++ b/frontend/projects/commitments-app/src/app/pages/profiles/profiles-page/profiles-page.component.html
@@ -5,7 +5,7 @@
 <section class="page-content-container">
   <ag-grid-angular class="ag-theme-material"
                    [columnDefs]="columnDefs"
-                   [rowData]="profiles$ | async"
+                   [rowData]="profiles()"
                    [pagination]="true"
                    [paginationPageSize]="5"
                    [localeText]="localeText"

--- a/frontend/projects/commitments-app/src/app/pages/profiles/profiles-page/profiles-page.component.ts
+++ b/frontend/projects/commitments-app/src/app/pages/profiles/profiles-page/profiles-page.component.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Component, inject } from '@angular/core';
+import { Component, DestroyRef, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { AgGridModule } from 'ag-grid-angular';
-import { BehaviorSubject, Subject } from 'rxjs';
-import { map, takeUntil } from 'rxjs';
+import { tap } from 'rxjs';
 import { ColDef, GridApi } from 'ag-grid-community';
 import { ProfileService } from '../../../services/profile.service';
 import { Profile } from '../../../models/profile';
@@ -33,13 +33,15 @@ import { PrimaryHeaderComponent } from '@commitments/ui';
 export class ProfilesPageComponent {
   private readonly _createProfileDialog = inject(CreateProfileDialogService);
   private readonly _profileService = inject(ProfileService);
+  private readonly _destroyRef = inject(DestroyRef);
 
-  public profiles$: BehaviorSubject<Array<Profile>> = new BehaviorSubject([]);
+  public readonly profiles = signal<Array<Profile>>([]);
 
   public ngOnInit() {
     this._profileService.get()
       .pipe(
-        map(x => this.profiles$.next(x)), takeUntil(this.onDestroy)
+        takeUntilDestroyed(this._destroyRef),
+        tap(x => this.profiles.set(x))
       )
       .subscribe();
   }
@@ -47,8 +49,8 @@ export class ProfilesPageComponent {
   public handleFABButtonClick() {
     this._createProfileDialog.create()
       .pipe(
-        map(x => this.addOrUpdate(x)),
-        takeUntil(this.onDestroy)
+        takeUntilDestroyed(this._destroyRef),
+        tap(x => this.addOrUpdate(x))
       )
       .subscribe();
   }
@@ -56,26 +58,25 @@ export class ProfilesPageComponent {
   public addOrUpdate(profile: Profile) {
     if (!profile) return;
 
-    const profiles = [...this.profiles$.value];
-    const i = profiles.findIndex((t) => t.profileId == profile.profileId);
-
-    if (i < 0) {
-      profiles.push(profile);
-    } else {
-      profiles[i] = profile;
-    }
-
-    this.profiles$.next(profiles);
+    this.profiles.update(profiles => {
+      const next = [...profiles];
+      const i = next.findIndex(t => t.profileId == profile.profileId);
+      if (i < 0) {
+        next.push(profile);
+      } else {
+        next[i] = profile;
+      }
+      return next;
+    });
   }
 
   public handleRemove($event) {
     const profile: Profile = $event.data;
 
-    const profiles = this.profiles$.value.filter(p => p.profileId !== profile.profileId);
-    this.profiles$.next(profiles);
+    this.profiles.update(profiles => profiles.filter(p => p.profileId !== profile.profileId));
 
     this._profileService.remove({ profile })
-      .pipe(takeUntil(this.onDestroy))
+      .pipe(takeUntilDestroyed(this._destroyRef))
       .subscribe();
   }
 
@@ -95,9 +96,5 @@ export class ProfilesPageComponent {
     { cellRenderer: "deleteRenderer", onCellClicked: $event => this.handleRemove($event), width: 30 }
   ];
 
-  public onDestroy: Subject<void> = new Subject<void>();
-
-  ngOnDestroy() {
-    this.onDestroy.next();
-  }
+  public localeText: any = {};
 }

--- a/frontend/projects/commitments-app/src/app/pages/tags/tags-page/tags-page.component.html
+++ b/frontend/projects/commitments-app/src/app/pages/tags/tags-page/tags-page.component.html
@@ -5,7 +5,7 @@
 <section class="page-content-container">
   <ag-grid-angular class="ag-theme-material"
                    [columnDefs]="columnDefs"
-                   [rowData]="tags$ | async"
+                   [rowData]="tags()"
                    [pagination]="true"
                    [frameworkComponents]="frameworkComponents"
                    [paginationPageSize]="5"

--- a/frontend/projects/commitments-app/src/app/pages/tags/tags-page/tags-page.component.ts
+++ b/frontend/projects/commitments-app/src/app/pages/tags/tags-page/tags-page.component.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Component, inject, Injector } from '@angular/core';
+import { Component, DestroyRef, inject, Injector } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { MatButtonModule } from '@angular/material/button';
@@ -9,11 +10,9 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { AgGridModule } from 'ag-grid-angular';
 import { Overlay } from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';
-import { Observable, Subject } from 'rxjs';
-import { map, takeUntil, tap } from 'rxjs';
+import { tap } from 'rxjs';
 import { ColDef } from 'ag-grid-community';
 import { TagsService } from '../../../services/tags.service';
-import { Tag } from '../../../models/tag';
 import { Store } from '../../../core/store';
 import { HubClient } from '../../../core/hub-client';
 import { OverlayRefWrapper } from '../../../core/overlay-ref-wrapper';
@@ -42,18 +41,22 @@ export class TagsPageComponent {
   private readonly _store = inject(Store);
   private readonly _tagsService = inject(TagsService);
   private readonly _translateService = inject(TranslateService);
+  private readonly _destroyRef = inject(DestroyRef);
+
+  public readonly tags = this._store.tags;
 
   public localeText: any = {};
 
   ngOnInit() {
     this._tagsService
       .get()
-      .pipe(takeUntil(this.onDestroy), map(x => this._store.tags$.next(x.tags)))
+      .pipe(takeUntilDestroyed(this._destroyRef), tap(x => this._store.tags.set(x.tags)))
       .subscribe();
 
     this._translateService
       .get(['Name', 'Page', 'of', 'to'])
       .pipe(
+        takeUntilDestroyed(this._destroyRef),
         tap(translations => {
           this.localeText = translations;
           this.columnDefs = [
@@ -77,7 +80,7 @@ export class TagsPageComponent {
   public handleChange($event) {
     this._tagsService
       .save({ tag: $event.data })
-      .pipe(takeUntil(this.onDestroy))
+      .pipe(takeUntilDestroyed(this._destroyRef))
       .subscribe();
   }
 
@@ -103,20 +106,10 @@ export class TagsPageComponent {
     params.api.sizeColumnsToFit();
   }
 
-  public get tags$(): Observable<Array<Tag>> {
-    return this._store.tags$;
-  }
-
-  public onDestroy: Subject<void> = new Subject<void>();
-
-  ngOnDestroy() {
-    this.onDestroy.next();
-  }
-
   public handleDelete($event) {
     this._tagsService
       .remove({ tagId: $event.data.tagId })
-      .pipe(takeUntil(this.onDestroy))
+      .pipe(takeUntilDestroyed(this._destroyRef))
       .subscribe();
   }
 

--- a/frontend/projects/commitments-app/src/app/pages/to-dos/to-dos-page/to-dos-page.component.html
+++ b/frontend/projects/commitments-app/src/app/pages/to-dos/to-dos-page/to-dos-page.component.html
@@ -5,7 +5,7 @@
 <section class="page-content-container">
   <ag-grid-angular class="ag-theme-material"
                    [columnDefs]="columnDefs"
-                   [rowData]="toDos$ | async"
+                   [rowData]="toDos()"
                    [pagination]="true"
                    [paginationPageSize]="5"
                    [localeText]="localeText"

--- a/frontend/projects/commitments-app/src/app/pages/to-dos/to-dos-page/to-dos-page.component.ts
+++ b/frontend/projects/commitments-app/src/app/pages/to-dos/to-dos-page/to-dos-page.component.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Component, inject } from '@angular/core';
+import { Component, DestroyRef, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { AgGridModule } from 'ag-grid-angular';
-import { BehaviorSubject, Subject } from 'rxjs';
-import { map, takeUntil } from 'rxjs';
+import { tap } from 'rxjs';
 import { ColDef, GridApi } from 'ag-grid-community';
 import { ToDoService } from '../../../services/to-do.service';
 import { ToDo } from '../../../models/to-do';
@@ -35,6 +35,11 @@ import { PrimaryHeaderComponent } from '@commitments/ui';
 export class ToDosPageComponent {
   private readonly _editToDoDialog = inject(EditToDoDialogService);
   private readonly _toDoService = inject(ToDoService);
+  private readonly _destroyRef = inject(DestroyRef);
+
+  public readonly toDos = signal<Array<ToDo>>([]);
+
+  public localeText: any = {};
 
   constructor() {
     this.handleRemoveToDoCellClick = this.handleRemoveToDoCellClick.bind(this);
@@ -42,14 +47,8 @@ export class ToDosPageComponent {
 
   public ngOnInit() {
     this._toDoService.get()
-      .pipe(map(x => this.toDos$.next(x)))
+      .pipe(takeUntilDestroyed(this._destroyRef), tap(x => this.toDos.set(x)))
       .subscribe();
-  }
-
-  public onDestroy: Subject<void> = new Subject<void>();
-
-  ngOnDestroy() {
-    this.onDestroy.next();
   }
 
   public columnDefs: Array<ColDef> = [
@@ -73,47 +72,40 @@ export class ToDosPageComponent {
     this._gridApi.sizeColumnsToFit();
   }
 
-  public toDos$: BehaviorSubject<Array<ToDo>> = new BehaviorSubject([]);
-
-  public toDosBehaviourSubject$: BehaviorSubject<Array<ToDo>> = new BehaviorSubject([]);
-
   public handleFabButtonClick() {
-    const overlayRefWrapper = this._editToDoDialog.create()
-      .pipe(map(toDo => this.addOrUpdate(toDo)), takeUntil(this.onDestroy))
+    this._editToDoDialog.create()
+      .pipe(takeUntilDestroyed(this._destroyRef), tap(toDo => this.addOrUpdate(toDo)))
       .subscribe();
   }
 
   public handleEditToDoCellClick($event) {
     this._editToDoDialog.create({ toDoId: $event.data.toDoId })
-      .pipe(map(toDo => this.addOrUpdate(toDo)), takeUntil(this.onDestroy))
+      .pipe(takeUntilDestroyed(this._destroyRef), tap(toDo => this.addOrUpdate(toDo)))
       .subscribe();
   }
 
   public handleRemoveToDoCellClick($event) {
     const toDo = $event.data;
 
-    const toDos: Array<ToDo> = [...this.toDos$.value];
-    const index = toDos.findIndex(x => x.toDoId == $event.data.toDoId);
-    toDos.splice(index, 1);
-    this.toDos$.next(toDos);
+    this.toDos.update(toDos => toDos.filter(x => x.toDoId != toDo.toDoId));
 
     this._toDoService.remove({ toDo })
-      .pipe(takeUntil(this.onDestroy))
+      .pipe(takeUntilDestroyed(this._destroyRef))
       .subscribe();
   }
 
   public addOrUpdate(toDo: ToDo) {
     if (!toDo) return;
 
-    const toDos = [...this.toDos$.value];
-    const i = toDos.findIndex((t) => t.toDoId == toDo.toDoId);
-
-    if (i < 0) {
-      toDos.push(toDo);
-    } else {
-      toDos[i] = toDo;
-    }
-
-    this.toDos$.next(toDos);
+    this.toDos.update(toDos => {
+      const next = [...toDos];
+      const i = next.findIndex(t => t.toDoId == toDo.toDoId);
+      if (i < 0) {
+        next.push(toDo);
+      } else {
+        next[i] = toDo;
+      }
+      return next;
+    });
   }
 }

--- a/frontend/projects/commitments-app/src/app/services/note-resolver.service.spec.ts
+++ b/frontend/projects/commitments-app/src/app/services/note-resolver.service.spec.ts
@@ -12,7 +12,7 @@ import { Store } from '../core/store';
 
 describe('noteResolver', () => {
   function setup(slug: string | undefined, getBySlug = jest.fn()) {
-    const store = { note$: { next: jest.fn(), value: {} } } as unknown as Store;
+    const store = { note: Object.assign(jest.fn(() => ({})), { set: jest.fn(), update: jest.fn() }) } as unknown as Store;
     TestBed.configureTestingModule({
       providers: [
         { provide: NotesService, useValue: { getBySlug } },
@@ -26,7 +26,7 @@ describe('noteResolver', () => {
 
   it('returns an empty Note without HTTP when slug is "new" (design 13 Slice D)', async () => {
     const getBySlug = jest.fn();
-    const store = { note$: { next: jest.fn(), value: {} } } as unknown as Store;
+    const store = { note: Object.assign(jest.fn(() => ({})), { set: jest.fn(), update: jest.fn() }) } as unknown as Store;
     TestBed.configureTestingModule({
       providers: [
         { provide: NotesService, useValue: { getBySlug } },
@@ -46,7 +46,7 @@ describe('noteResolver', () => {
   it('fetches by slug and pushes to the store for non-"new" slugs', async () => {
     const fetched = { note: { noteId: 'abc', title: 'T', slug: 'the-slug', body: 'x' } };
     const getBySlug = jest.fn().mockReturnValue(of(fetched));
-    const store = { note$: { next: jest.fn(), value: {} } } as unknown as Store;
+    const store = { note: Object.assign(jest.fn(() => ({})), { set: jest.fn(), update: jest.fn() }) } as unknown as Store;
     TestBed.configureTestingModule({
       providers: [
         { provide: NotesService, useValue: { getBySlug } },
@@ -60,6 +60,6 @@ describe('noteResolver', () => {
     await TestBed.runInInjectionContext(() => firstValueFrom(noteResolver(route, state) as any));
 
     expect(getBySlug).toHaveBeenCalledWith({ slug: 'the-slug' });
-    expect(store.note$.next).toHaveBeenCalledWith(fetched.note);
+    expect((store.note as any).set).toHaveBeenCalledWith(fetched.note);
   });
 });

--- a/frontend/projects/commitments-app/src/app/services/note-resolver.service.ts
+++ b/frontend/projects/commitments-app/src/app/services/note-resolver.service.ts
@@ -16,11 +16,11 @@ export const noteResolver: ResolveFn<Note> = (route, state) => {
 
   if (!slug || slug === 'new') {
     const note = new Note();
-    store.note$.next(note);
+    store.note.set(note);
     return of(note);
   }
 
   return notesService
     .getBySlug({ slug })
-    .pipe(tap(x => store.note$.next(x.note)), map(x => x.note));
+    .pipe(tap(x => store.note.set(x.note)), map(x => x.note));
 };

--- a/frontend/projects/commitments-app/src/app/services/tags-resolver.service.ts
+++ b/frontend/projects/commitments-app/src/app/services/tags-resolver.service.ts
@@ -12,5 +12,5 @@ export const tagsResolver: ResolveFn<Tag[]> = (route, state) => {
   const tagsService = inject(TagsService);
   const store = inject(Store);
 
-  return tagsService.get().pipe(tap(x => store.tags$.next(x.tags)), map(x => x.tags));
+  return tagsService.get().pipe(tap(x => store.tags.set(x.tags)), map(x => x.tags));
 };


### PR DESCRIPTION
## Summary
This PR modernizes the codebase by migrating from RxJS Subjects/BehaviorSubjects and the async pipe to Angular signals and the new `@angular/core/rxjs-interop` utilities. This improves performance, reduces boilerplate, and aligns with Angular's latest best practices.

## Key Changes

### Core API Migrations
- **Input/Output decorators → Signal-based APIs**: Replaced `@Input()`, `@Output()`, and `@ViewChild()` with `input()`, `output()`, and `viewChild()` functions
- **Subject-based state → Signals**: Converted `BehaviorSubject` and `Subject` instances to `signal()` for reactive state management
- **Observable subscriptions → takeUntilDestroyed**: Replaced manual `Subject`-based unsubscribe patterns with `takeUntilDestroyed()` using injected `DestroyRef`
- **Async pipe removal**: Eliminated `AsyncPipe` usage by converting observables to signals with `toSignal()` and updating templates to call signal functions

### Component-Specific Updates
- **Auto-complete chip list**: Migrated to signal-based inputs/outputs and converted filtered items observable to a signal using `toSignal()`
- **Page components** (Cards, Behaviours, ToDos, Commitments, Activities, etc.): Replaced `BehaviorSubject` state with signals and simplified subscription management
- **Dialog components**: Converted observable-based state to signals with `toSignal()` and removed manual subscription cleanup
- **Master page**: Removed `AsyncPipe` dependency and converted profile data to signals with computed properties and effects

### Template Updates
- Updated all templates to call signal functions (e.g., `items()` instead of `items | async`)
- Removed `*ngIf="!(observable | async)"` patterns in favor of computed signals
- Updated property bindings to use signal function calls

### Store and Services
- Migrated `Store` class from `BehaviorSubject` to signal-based state management
- Updated service resolvers to work with signal-based state

## Implementation Details
- Used `toSignal()` with `initialValue` option for observables that need signal conversion
- Leveraged `computed()` for derived state calculations
- Applied `effect()` for side effects in components like master-page
- Maintained backward compatibility with existing RxJS operators (`tap`, `map`, etc.) where needed
- Removed unused RxJS imports (`switchMap`, `takeUntil`, `map` for state updates)

https://claude.ai/code/session_01DNN2dKup4EetHrcxSxT9xY